### PR TITLE
docs: document frontend user and realtime processes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,30 @@
 - There is currently no `test` script in `package.json`; do not claim a Frontend unit test suite ran.
 - Set `VITE_BASE_URL=http://localhost/api` for the normal local Nginx-backed environment.
 - This repository has no production deployment workflow. After a validated change is merged here, release it by advancing the `Frontend` submodule in a pull request to root `CoDuels`.
+
+## Frontend process documentation
+
+- Before changing a user process, read its document in `docs/processes`.
+- Do not analyze a React component independently of Redux, RTK Query, browser storage, and backend events.
+- For every duel-flow change, check the HTTP request, WebSocket event, Redux transition, cache update, navigation, reload behavior, and multiple-tab behavior.
+- The backend is the source of truth for duel, invitation, group, tournament, and submission state.
+- Persisted Redux must not automatically be treated as current backend state.
+- When adding a persisted field, document its owner, reset trigger, schema version, user-switch behavior, and tab behavior.
+- Keep one authenticated WebSocket lifecycle in `features/duel-session/api/duelSessionApi.ts` when changing realtime behavior.
+- Do not create a second competing user WebSocket.
+- A WebSocket-event change requires corresponding frontend handler, applicable runtime validation, process documentation, backend contract documentation, and tests.
+- Matchmaking changes must account for disconnect and backend cleanup of pending duels.
+- Invitation-flow changes must treat Friendly, Group, and Tournament types separately.
+- An RTK Query endpoint change must account for every cache entry and manual cache update that represents the affected state.
+- Do not treat cache invalidation as equivalent to an immediate UI change.
+- Submission-flow changes must account for out-of-order and duplicate WebSocket events.
+- A terminal submission state must not be replaced by an older non-terminal state.
+- Code-editor state changes must account for reload, logout, user switch, and multiple tabs.
+- Code-sync changes must account for privacy configuration and `should_show_opponent_solution`.
+- Anti-cheat tracking changes must remain synchronized with Duely and Analyzer.
+- Do not claim reliable delivery from browser lifecycle events without evidence.
+- UI permission checks do not replace backend authorization.
+- If documentation and code differ, report the mismatch explicitly.
+- Current behavior must not automatically be treated as the correct product requirement.
+- Keep `Proposed requirements` separate from `Current behavior`.
+- When a process changes, update or add tests for state transitions, reload, multiple tabs, duplicate events, out-of-order events, HTTP failure, WebSocket failure, cache reconciliation, permission errors, and persisted state.

--- a/docs/processes/README.md
+++ b/docs/processes/README.md
@@ -1,0 +1,59 @@
+# CoDuels Frontend processes
+
+This directory documents end-to-end client behavior observed in the current
+React/Redux code and the corresponding Duely, Taski, Exesh, and Analyzer
+contracts. An implementation fact is not automatically a product requirement.
+
+## Process map
+
+| User/client process | Document | Primary client owner |
+| --- | --- | --- |
+| Store rehydration, theme, routes, protected pages | [Application bootstrap and routing](application-bootstrap-and-routing.md) | `app` |
+| Login, logout, and refresh mutex | [Authentication and token refresh](authentication-and-token-refresh.md) | `features/auth`, `shared/api` |
+| Redux, cache, local/component/browser state catalog | [Client state ownership](client-state-ownership.md) | store and browser |
+| Ticket, socket, events, code sync, two tabs | [Realtime connection](realtime-connection.md) | `features/duel-session` |
+| Persisted `idle/searching/active` reconciliation | [Duel session lifecycle](duel-session-lifecycle.md) | duel-session slice/manager |
+| Start/cancel rating search | [Ranked matchmaking](ranked-matchmaking.md) | Home/session button |
+| Friendly, group-membership, and tournament invitations | [Duel invitations](duel-invitations.md) | Home and invitation APIs |
+| Membership, roles, permissions, sections | [Groups](groups.md) | group pages/entities |
+| Manager-created two-user duels | [Group duels](group-duels.md) | Group page |
+| Create/start/bracket/duel invitations | [Tournaments](tournaments.md) | group/tournament pages |
+| Duel access, nested routes, tasks opening | [Duel page and task navigation](duel-page-and-task-navigation.md) | Duel page/widgets |
+| Monaco persistence and opponent synchronization | [Editor state and code sync](editor-state-and-code-sync.md) | code panel/session socket |
+| Submit and reconcile judging state | [Submissions](submissions.md) | submit-code and task panel |
+| Capture/batch behavior actions | [Anti-cheat actions](anti-cheat-actions.md) | anti-cheat feature |
+| Endpoint cache keys/tags/manual changes | [RTK Query cache](rtk-query-cache.md) | shared API slice |
+| Browser persistence and tab conflicts | [Reload recovery and multiple tabs](reload-recovery-and-multiple-tabs.md) | redux-persist/storage |
+| Cross-process degraded paths | [Failure handling](failure-handling.md) | all layers |
+| HTTP and WebSocket field compatibility | [Backend contracts](backend-contracts.md) | Frontend plus backend producers |
+
+Use the [glossary](glossary.md) to distinguish local session, RTK cache, backend
+state, and browser-storage scopes. Unresolved intent and confirmed/potential
+defects are consolidated in [open questions](open-questions.md).
+
+## Current production data path
+
+```mermaid
+flowchart LR
+    ui["React pages/widgets"] --> redux["Redux + persisted slices"]
+    ui --> cache["RTK Query cache"]
+    cache --> duely["Duely HTTP"]
+    manager["DuelSessionManager"] --> socket["one WebSocket per tab"]
+    socket <--> duely
+    duely --> taski["Taski testing"]
+    taski --> exesh["Exesh execution"]
+    editor["Monaco action queue"] --> duely
+    duely --> analyzer["Analyzer after duel"]
+```
+
+Taski/Exesh production status propagation is REST polling inside the backend;
+the browser sees derived Duely WebSocket messages, not their raw histories.
+
+## Test and validation baseline
+
+There are no `*.test.*`/`*.spec.*` files, test script, Storybook, Playwright,
+Cypress, or MSW handlers/mock data. `msw` is installed but unused in source.
+The available source checks are `pnpm lint`, `pnpm fsd:lint`, and `pnpm build`;
+they are not required for this Markdown-only change. No Markdown-lint
+configuration is present.
+

--- a/docs/processes/anti-cheat-actions.md
+++ b/docs/processes/anti-cheat-actions.md
@@ -63,16 +63,26 @@ actions that are discarded on the next disabled flush.
 
 ## Backend state assumptions
 
-Duely verifies authenticated user against payload, unfinished duel, membership,
-UUID, positive sequence, timestamp, duel ID, and one-character task key, then
-persists accepted events. Analyzer expects synchronized action names/fields and
-ordered feature input. Client-generated identity/sequence is not trusted truth.
+Duely rejects the whole batch if any action's `UserId` differs from the
+authenticated command user. It structurally validates a non-empty `EventId`, a
+positive sequence and duel ID, a non-default timestamp, and a non-default
+one-character `TaskKey`. It then saves actions whose duel exists and is not
+finished, silently filtering actions for missing or finished duels.
+
+The save path does **not** verify that the authenticated user participates in
+the referenced duel, does not verify that `TaskKey` exists in that duel, and
+does not use `EventId` to detect retransmission. Analyzer expects synchronized
+action names/fields and ordered feature input, but client-generated identity,
+sequence, and event IDs are not proof of a valid or unique domain event.
 
 ## State ownership
 
-The browser owns unsent memory only. Duely owns accepted durable actions and
-deduplication constraints. Analyzer owns derived features/score. Neither Redux
-nor browser storage retains the queue; no client receipt proves persistence.
+The browser owns unsent memory only. Duely owns the durable action rows it
+accepts, but the current persistence model has no unique constraint on
+`EventId`; multiple rows can represent the same retransmitted client event.
+Analyzer owns derived features/score. Neither Redux nor browser storage retains
+the queue, and the client receives no per-event acceptance or deduplication
+receipt.
 
 ## UI effects
 
@@ -88,10 +98,13 @@ and payload/platform limits apply; it is not a delivery guarantee.
 
 ## Idempotency and duplicate handling
 
-UUID event IDs allow backend deduplication if a batch is retried, but the client
-does not retry. Sequence restarts create repeated low values across batches;
-ordering must not assume global monotonicity. Concurrent tabs create independent
-UUID/sequence streams for the same duel/user.
+Action upload is not idempotent. The Frontend generates UUID `event_id` values,
+but Duely neither looks them up before insert nor enforces a unique database
+constraint. Reposting the same batch can therefore create duplicate rows with
+the same `EventId` and sequence. The current client does not retry automatically,
+but user/browser/network behavior or a future retry can still retransmit.
+Sequence restarts create repeated low values across batches, and concurrent tabs
+create independent UUID/sequence streams for the same duel/user.
 
 ## Ordering assumptions
 
@@ -124,23 +137,34 @@ editing session.
 
 ## Test coverage
 
-- **Existing tests:** none.
+- **Existing Frontend tests:** none. Focused Backend tests cover matching/mixed
+  user IDs and filtering finished-duel actions; they do not establish
+  participant authorization, task existence, or duplicate prevention.
 - **Needed unit/integration:** every action payload, batches 1/200/201, non-2xx,
-  rejection, events-during-flush, token change, sequence/dedup validation.
+  rejection, events-during-flush, token change, repeated `EventId`/batch,
+  missing/finished duel, non-participant user, and nonexistent task key.
 - **Needed E2E:** real editing/run/submit order, offline/reload/close/hidden,
   inactive phase, two tabs, refresh expiry, and Analyzer-compatible dataset.
 
 ## Current guarantees
 
 Known actions receive UUIDs and ISO timestamps; a normal eligible online flush
-sends no more than 200 per request in queue order; Duely revalidates identity and
-domain constraints; action types currently match the Analyzer contract.
+sends no more than 200 per request in queue order. Duely rejects actions whose
+payload `UserId` differs from the authenticated user, applies structural
+validation, and persists only actions referencing an existing unfinished duel.
+It does not currently guarantee duel participation, task existence, unique
+`EventId`, or duplicate suppression. Action types currently match the Analyzer
+contract.
 
 ## Open questions
 
-Required delivery rate, sequence scope, retry/retention/privacy policy, accepted
-response schema, clock handling, cross-tab semantics, and observability thresholds
-must be defined before calling this reliable telemetry.
+Should Duely require the authenticated user to participate in the referenced
+duel and require `TaskKey` to exist? Is `EventId` intended to become an
+idempotency key, and if so what migration/conflict policy applies to existing
+duplicates? Required delivery rate, sequence scope, retry/retention/privacy
+policy, accepted-count/duplicate response schema, clock handling, cross-tab
+semantics, and observability thresholds must be defined before calling this
+reliable telemetry.
 
 ## Proposed requirements
 
@@ -148,4 +172,3 @@ Check HTTP status and use acknowledged retry with bounded durable/user-scoped
 outbox; keep monotonic stream sequence/revision; serialize concurrent flushes;
 coordinate tabs; refresh auth safely; publish loss metrics; contract-test Duely
 and Analyzer schemas; never claim unload delivery is guaranteed.
-

--- a/docs/processes/anti-cheat-actions.md
+++ b/docs/processes/anti-cheat-actions.md
@@ -1,0 +1,151 @@
+# Anti-cheat actions
+
+## Purpose
+
+Describe browser behavior-action capture, event shape, in-memory batching,
+flush/loss semantics, and the contract with Duely and Analyzer.
+
+## Participants
+
+Monaco/action hooks, run and submit controls, anti-cheat queue module, DuelPage,
+auth/duelSession state, browser lifecycle, Duely action endpoint/storage, and
+Analyzer after the duel.
+
+## Entry points
+
+Choose language, write/delete/paste/cut, move cursor, run sample/custom test,
+submit, 5-second interval, page hide/unload, visibility hidden, component
+cleanup, token loss, reload, socket/session changes, and backend rejection.
+
+## Preconditions
+
+Tracking is enabled for a known participant. Each event needs duel/user/task
+context as applicable. Sending additionally uses a predicate based on local
+`phase=active` and a current token; Duely performs definitive validation.
+
+## Current behavior
+
+Exact action types are `ChooseLanguage`, `WriteCode`, `DeleteCode`, `PasteCode`,
+`CutCode`, `MoveCursor`, `RunSampleTest`, `RunCustomTest`, and `SubmitSolution`.
+Events contain UUID `event_id`, per `${duelId}:${userId}` `sequence_id`, ISO
+timestamp, duel/user/type and optional task/action fields. They live only in a
+module-memory queue. Flush is triggered every 5 seconds and on lifecycle events,
+sends batches up to 200 using `fetch(..., keepalive: true)`, and does not inspect
+`response.ok`. `sendBeacon` is not used.
+
+Flush returns while another flush runs. If `shouldSend` is false, fetch rejects,
+the token disappears, or the response is non-2xx, `finally` clears the whole
+queue and sequence map; there is no retry. Events added while flushing can be
+included in another loop iteration or removed by final cleanup. Sequence IDs
+therefore restart after every flush rather than remaining monotonic for a duel.
+
+```mermaid
+flowchart TD
+    action["Editor/run/submit action"] --> queue["Memory queue + per-actor sequence"]
+    queue --> trigger{"5 s, hidden, unload, cleanup"}
+    trigger --> eligible{"token and shouldSend?"}
+    eligible -- yes --> batch["fetch keepalive, batches <= 200"]
+    eligible -- no --> clear["Clear queue and sequence map"]
+    batch --> result{"fetch resolved?"}
+    result -- yes, including non-2xx --> clear
+    result -- rejected --> clear
+    clear --> loss["No retry/acknowledged durable outbox"]
+    batch --> duely["Duely validates and persists"]
+    duely --> analyzer["Analyzer feature extraction/scoring"]
+```
+
+## Client state transitions
+
+Capture appends and increments a memory counter. Flush sets `isFlushing`, slices
+and sends, then always empties queue/counters and clears the flag. Token-change
+effects clear queued data. Participant page with local phase idle can capture
+actions that are discarded on the next disabled flush.
+
+## Backend state assumptions
+
+Duely verifies authenticated user against payload, unfinished duel, membership,
+UUID, positive sequence, timestamp, duel ID, and one-character task key, then
+persists accepted events. Analyzer expects synchronized action names/fields and
+ordered feature input. Client-generated identity/sequence is not trusted truth.
+
+## State ownership
+
+The browser owns unsent memory only. Duely owns accepted durable actions and
+deduplication constraints. Analyzer owns derived features/score. Neither Redux
+nor browser storage retains the queue; no client receipt proves persistence.
+
+## UI effects
+
+Tracking is invisible and failures do not block editor/run/submit or notify the
+user. Spectator editing paths are disabled in UI. Local active-phase mismatch can
+silently remove participant events even while the duel is valid backend-side.
+
+## Network effects
+
+Batches use raw authenticated fetch rather than RTK Query/refresh mutex. A stale
+access token can fail without refresh/retry. Lifecycle `keepalive` is best effort
+and payload/platform limits apply; it is not a delivery guarantee.
+
+## Idempotency and duplicate handling
+
+UUID event IDs allow backend deduplication if a batch is retried, but the client
+does not retry. Sequence restarts create repeated low values across batches;
+ordering must not assume global monotonicity. Concurrent tabs create independent
+UUID/sequence streams for the same duel/user.
+
+## Ordering assumptions
+
+Actions are queued in callback order within one JS context, but asynchronous
+flushes, events added during flush, debounced editor updates, system clocks, and
+tabs have no global order. Analyzer must not infer strict chronology solely from
+restarting sequence IDs.
+
+## Failure handling
+
+Non-2xx is treated as successful delivery because only promise rejection is
+observable and both paths clear data. Rejection, offline, unload limits, reload,
+crash, and disabled sending all lose events. No backoff, durable outbox, metric,
+receipt, or user-visible signal exists.
+
+## Reload and multiple tabs
+
+Reload/crash discards queue and resets sequences. Each tab captures and flushes
+independently; socket replacement does not coordinate anti-cheat. Shared editor
+state can produce action streams that do not correspond to a single ordered
+editing session.
+
+## Implementation references
+
+- anti-cheat action types/queue/hooks under `src/features/anti-cheat`
+- Monaco action tracking integration under `src/widgets/code-panel`
+- run/submit action call sites
+- `src/pages/duel` participant/active gating
+- Backend Duely user-action DTO/use case and Analyzer schemas/features
+
+## Test coverage
+
+- **Existing tests:** none.
+- **Needed unit/integration:** every action payload, batches 1/200/201, non-2xx,
+  rejection, events-during-flush, token change, sequence/dedup validation.
+- **Needed E2E:** real editing/run/submit order, offline/reload/close/hidden,
+  inactive phase, two tabs, refresh expiry, and Analyzer-compatible dataset.
+
+## Current guarantees
+
+Known actions receive UUIDs and ISO timestamps; a normal eligible online flush
+sends no more than 200 per request in queue order; Duely revalidates identity and
+domain constraints; action types currently match the Analyzer contract.
+
+## Open questions
+
+Required delivery rate, sequence scope, retry/retention/privacy policy, accepted
+response schema, clock handling, cross-tab semantics, and observability thresholds
+must be defined before calling this reliable telemetry.
+
+## Proposed requirements
+
+Check HTTP status and use acknowledged retry with bounded durable/user-scoped
+outbox; keep monotonic stream sequence/revision; serialize concurrent flushes;
+coordinate tabs; refresh auth safely; publish loss metrics; contract-test Duely
+and Analyzer schemas; never claim unload delivery is guaranteed.
+

--- a/docs/processes/application-bootstrap-and-routing.md
+++ b/docs/processes/application-bootstrap-and-routing.md
@@ -1,0 +1,163 @@
+# Application bootstrap and routing
+
+## Purpose
+
+Create the client runtime, restore persisted state, apply theme, protect routes,
+mount the single duel-session manager, and render the selected page.
+
+## Participants
+
+Browser, React StrictMode/root, Providers, Redux store/API middleware,
+redux-persist/PersistGate, ErrorBoundary, AppRouter, DuelSessionManager, Layout,
+ProtectedRoute, pages/widgets, RTK Query, and Duely.
+
+## Entry points
+
+Initial URL load, reload, history navigation, auth-state rehydration, logout,
+route error, or direct deep link.
+
+## Preconditions
+
+`#root` exists, bundles/configured `VITE_BASE_URL` load, and persisted JSON is
+readable enough for redux-persist or reducers can use initial state.
+
+## Current behavior
+
+`main.tsx` mounts `<App/>` in StrictMode. Store construction registers persisted
+auth, duelSession, codeEditor, theme reducers; the unpersisted RTK Query reducer;
+and API middleware, then creates the persistor. Providers wrap the application
+in ErrorBoundary, Redux Provider, and PersistGate with `loading=null`, so routes
+do not render until bootstrapping completes and the page can be blank meanwhile.
+
+AppRouter reads persisted theme, applies `.app--{mode}`, mounts exactly one
+DuelSessionManager outside RouterProvider, then starts the browser router.
+Layout always renders Header and Outlet. Suspense uses Loader for route elements,
+although pages are currently static imports. Root `errorElement` is Fallback.
+
+`/auth` is public even when already authenticated. Protected routes are `/`,
+`/profile/:userNickname`, `/groups`, `/groups/:groupId`,
+`/groups/:groupId/members`, `/groups/:groupId/duels`,
+`/groups/:groupId/tournaments`,
+`/groups/:groupId/tournaments/:tournamentId`, and `/duel/:duelId` with nested
+`/duel/:duelId/description`, `/duel/:duelId/submissions`, and
+`/duel/:duelId/submissions/:submissionId`; duel index redirects to `description`.
+`/groups/:groupId` redirects to `members`. ProtectedRoute skips
+`getMe` without token, redirects to `/auth`, and with a token waits for `getMe`.
+Only explicit 401 redirects; any other error remains Loader indefinitely. It
+does not preserve the original URL. RTK cache is recreated empty on reload.
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant P as Providers/PersistGate
+    participant S as Redux/localStorage
+    participant R as Router/ProtectedRoute
+    participant D as Duely
+    participant M as DuelSessionManager
+    B->>P: load URL and React bundle
+    P->>S: create store and rehydrate four slices
+    S-->>P: persisted auth/session/editor/theme
+    P->>M: mount once after rehydration
+    P->>R: render route
+    R->>D: GET /users/iam with persisted token
+    D-->>R: current user (or refresh path on 401)
+    R-->>B: protected page
+    M->>D: POST ticket, then WebSocket after user is stored
+```
+
+## Client state transitions
+
+`persist bootstrap: pending -> rehydrated`; `auth.user: persisted/null -> getMe
+result`; route `requested -> Loader/redirect/page/Fallback`. No persisted RTK
+cache transition exists.
+
+## Backend state assumptions
+
+Persisted token/user are provisional. `GET /users/iam` authenticates protected
+pages and can trigger refresh. Duel/session reconciliation is separate and
+route-dependent; direct duel access relies on `GET /duels/:id` authorization.
+
+## State ownership
+
+| State | Owner/source of truth | Redux | RTK Query | local state | sessionStorage | localStorage | Survives reload |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Tokens/user snapshot | Duely; client cache | auth | getMe | No | No | `persist:auth` | Yes |
+| Theme | client preference | theme | No | No | No | `persist:theme` | Yes |
+| Route/location | browser router | No | No | router | No | No | URL yes |
+| API cache | HTTP responses | API reducer | Yes | No | No | No | No |
+| Modal/page state | component | Usually no | No | Yes | Some Home state | Some explicit keys | Key-dependent |
+
+## UI effects
+
+PersistGate shows blank during rehydration. Suspense/protected queries show
+Loader. Missing token/401 redirects with `replace` to `/auth`; network failure
+can show endless Loader. Group/duel nested redirects replace history. Invalid
+or thrown route renders generic Fallback; invalid numeric duel IDs lack a
+dedicated parent error view.
+
+## Network effects
+
+ProtectedRoute subscribes to cached `getMe`; auth refresh can replay it. Manager
+starts ticket/socket only after `auth.user` is non-null. Header/child pages may
+start their own queries after route render. No cache is restored from disk.
+
+## Idempotency and duplicate handling
+
+StrictMode may replay effects in development. The manager ref prevents its
+normal effect from dispatching a second subscription in the same instance, and
+RTK Query deduplicates identical cache keys. The effect provides no component-
+unmount cleanup, so an abnormal manager remount can leave a subscription alive.
+
+## Ordering assumptions
+
+PersistGate orders rehydration before AppRouter/managers/queries. `getMe` success
+must populate auth user before socket subscription. Route navigation and cache
+responses are otherwise asynchronous; no transaction binds them.
+
+## Failure handling
+
+ErrorBoundary catches render errors. Storage parsing has library/default
+fallback behavior but no app migration UI. Missing base URL/network can cause
+getMe Loader, refresh/logout, or page errors. No explicit offline route, retry
+button, 404 page, or original-location return exists.
+
+## Reload and multiple tabs
+
+Each tab builds its own store/router/cache/manager/socket. localStorage is
+shared but Redux is not live-synchronized; sessionStorage is tab-scoped. Reload
+rehydrates slices and empties cache; PersistGate prevents a flash of reducer
+initial state. A second tab can replace the first backend socket.
+
+## Implementation references
+
+- `src/main.tsx`, `src/app/{App,store}.tsx`, `src/app/store.ts`
+- `src/app/providers/Providers.tsx`
+- `src/app/router/{AppRouter,router,ProtectedRoute,GroupRedirect}.tsx`
+- `src/app/layout/Layout.tsx`
+- `src/shared/config/routes/appRoutes.ts`
+
+## Test coverage
+
+- **Existing tests/MSW:** none; MSW has no handlers.
+- **Needed unit/integration:** persist configs, ProtectedRoute result matrix,
+  router paths/redirects, error boundary, manager mount/unmount.
+- **Needed browser/E2E:** authorized cold load, corrupt/old storage, offline
+  getMe, deep links, invalid IDs/403, reload, logout redirect, StrictMode, and
+  two-tab bootstrap.
+
+## Current guarantees
+
+PersistGate blocks child rendering until redux-persist bootstraps; four named
+slices (not RTK cache) are version-1 persisted; one manager is present in the
+normal AppRouter tree; all non-auth declared pages use ProtectedRoute.
+
+## Open questions
+
+Desired offline/404/original-route UX, persistence migration, manager abnormal
+remount cleanup, and whether authenticated users may visit `/auth` are unclear.
+
+## Proposed requirements
+
+Define route/error/offline recovery, preserve intended deep links through auth,
+version/migrate persisted state, add explicit manager cleanup, validate IDs and
+authorization states, and cover cold/reload/two-tab bootstrap with E2E tests.

--- a/docs/processes/authentication-and-token-refresh.md
+++ b/docs/processes/authentication-and-token-refresh.md
@@ -1,0 +1,171 @@
+# Authentication and token refresh
+
+## Purpose
+
+Authenticate/register a user, persist tokens/current user, serialize access-
+token refresh within one tab, and end the local session on logout/failure.
+
+## Participants
+
+User, AuthPage/forms, auth RTK endpoints/slice, shared base query, refresh mutex,
+localStorage/redux-persist, ProtectedRoute/getMe, DuelSessionManager, editor and
+anti-cheat features, and Duely user endpoints.
+
+## Entry points
+
+Login/register form submit, protected API request, 401 or `FETCH_ERROR`, cold
+rehydration, explicit Header logout, invalid refresh response, or network loss.
+
+## Preconditions
+
+Login fields satisfy Superstruct form rules. Refresh needs a persisted refresh
+token. Authenticated requests use the current Redux access token in Authorization.
+
+## Current behavior
+
+Login posts snake-case-compatible `{nickname,password}` but trusts the response
+as `TokenPair` at runtime; the fulfilled matcher stores both tokens, invalidates
+User tags, then navigation goes to `/`. ProtectedRoute calls `getMe`, whose
+fulfilled matcher stores the current user. Registration first creates the user,
+then performs the same login. The previous/original URL is not restored.
+
+For each API request, `prepareHeaders` reads the current store token. On 401 or
+`FETCH_ERROR` (except `/users/refresh`) with a refresh token, refresh waits for a
+module-level mutex. The owner calls raw `fetch POST /users/refresh` with
+`refresh_token`, validates exact token fields using Superstruct, dispatches
+`setTokens`, releases, and the base query retries the original request, whose
+headers are rebuilt from current store. A second retry 401 logs out. A waiter
+can use a captured old state and returns its old token after another refresh;
+the return only gates retry, while headers themselves re-read Redux. Mutex and
+state are not cross-tab.
+
+Any non-OK refresh, invalid JSON/shape, or thrown fetch logs out. Consequently a
+temporary offline `FETCH_ERROR` can turn into logout. Refresh itself is excluded
+from recursive refresh.
+
+Header logout only dispatches `auth/logout`. Code editor also listens and clears;
+manager observes `user=null`, resets duel session and unsubscribes; token change
+clears anti-cheat queue. RTK Query cache, Home/run/code-tab sessionStorage,
+result flags, and local configuration cache are not explicitly cleared. Theme
+survives.
+
+```mermaid
+sequenceDiagram
+    participant A as Request A
+    participant B as Request B
+    participant Q as baseQuery/mutex
+    participant D as Duely
+    participant S as Redux
+    A->>D: request with expired access token
+    B->>D: request with expired access token
+    D-->>A: 401
+    D-->>B: 401
+    A->>Q: acquire mutex
+    A->>D: POST /users/refresh
+    B->>Q: waitForUnlock
+    D-->>A: access_token + refresh_token
+    A->>S: setTokens
+    A->>Q: release
+    A->>D: replay with token read from Redux
+    B->>D: replay only if captured return is truthy; headers read Redux
+```
+
+## Client state transitions
+
+`auth: anonymous -> tokens/no user -> tokens+user`; refresh `old tokens -> new
+tokens` or `old tokens -> null`; logout `user/tokens -> null`, followed by duel
+session/editor/queue cleanup through separate observers/reducers.
+
+## Backend state assumptions
+
+Duely is authoritative for credentials, refresh validity, and current user.
+Tokens restored from disk are untrusted until `getMe`; no proactive expiry
+decode exists. Backend logout/revocation endpoint is not called.
+
+## State ownership
+
+| State | Owner/source of truth | Redux | RTK Query | local state | sessionStorage | localStorage | Survives reload |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Access/refresh token | Duely-issued/client held | auth | No | No | No | `persist:auth` | Yes |
+| Current user snapshot | Duely `iam` | auth | getMe cache | No | No | `persist:auth` | Yes |
+| Refresh lock | one JS module/tab | No | No | module mutex | No | No | No |
+| Login form/status | component | No | mutation state | Yes | No | No | No |
+| Old API data | backend snapshots | API reducer | Yes | No | No | No | Until page refresh/cache expiry |
+
+## UI effects
+
+Forms disable during their mutations and display mapped errors. Success goes to
+home. Protected 401 redirects to auth; non-401 error is an indefinite Loader.
+Logout on a protected page causes redirect after state change. No cross-tab
+logout notice or "session expired/offline" distinction exists.
+
+## Network effects
+
+Login/register/getMe use RTK base query. Refresh uses raw fetch and one replay.
+Login/register broadly invalidate User tags. Logout sends nothing and resets no
+API cache. Socket closes through subscription cleanup after auth user clears.
+
+## Idempotency and duplicate handling
+
+Form loading generally prevents a second submit after mutation starts. Same-tab
+refresh is serialized; cross-tab refreshes can rotate tokens concurrently.
+Register retry can encounter an already-created user. Logout is locally
+idempotent but asynchronous persistence can race another tab's writes.
+
+## Ordering assumptions
+
+Login token matcher must run before protected navigation/getMe. Refresh waiters
+assume mutex owner updated shared Redux, but use captured state for their return.
+Logout cleanup happens in multiple effects/reducers with no single atomic reset.
+
+## Failure handling
+
+Login/register errors remain anonymous and show a banner. Refresh failure clears
+credentials, including on offline exceptions. Invalid login response has no
+runtime guard and may store undefined fields; invalid refresh response is
+guarded and logs out. Old RTK/browser data can remain visible after user switch.
+
+## Reload and multiple tabs
+
+Tokens/user rehydrate from shared localStorage. Tabs keep independent Redux and
+mutexes; writes do not dispatch logout/token changes to peers. One tab can use
+or rewrite stale credentials after another logs out/refreshes. sessionStorage
+forms remain independent; shared code/tokens use last-writer-wins persistence.
+
+## Implementation references
+
+- `src/features/auth/{api/authApi,model/authSlice,model/authStruct}.ts`
+- `src/features/auth/ui/{LoginForm,RegisterForm}`
+- `src/shared/api/{api,token/refreshAuthToken}.ts`
+- `src/app/store.ts`, `src/app/router/ProtectedRoute.tsx`
+- `src/widgets/header/ui/Header.tsx`
+- Backend `UsersController`, token DTO/refresh use cases
+
+## Test coverage
+
+- **Existing tests/MSW:** none.
+- **Needed unit/integration:** form validation/mapping, login response validation,
+  all base-query refresh branches, mutex waiters, replay headers, logout reset.
+- **Needed browser/E2E:** expired token with parallel requests, offline versus
+  401, invalid refresh, reload, same-tab user switch, two-tab refresh/logout,
+  cache/code leakage, and socket shutdown.
+
+## Current guarantees
+
+Current access token is read for every base-query header; refresh response is
+runtime-validated; one tab has at most one mutex-owner refresh at a time;
+original request is replayed at most once by this wrapper; logout clears auth
+and editor/session through current component wiring.
+
+## Open questions
+
+Why `FETCH_ERROR` refreshes/logs out, token storage policy, cross-tab session
+coordination, full logout reset scope, and login runtime validation are unresolved.
+
+## Proposed requirements
+
+Validate all auth responses, distinguish offline from invalid refresh, re-read
+state after mutex wait, coordinate token rotation/logout across tabs, atomically
+reset user-owned cache/storage/session, consider HttpOnly refresh storage, and
+E2E-test concurrent expiry and user switching.
+

--- a/docs/processes/backend-contracts.md
+++ b/docs/processes/backend-contracts.md
@@ -19,8 +19,10 @@ ticket/socket open, outgoing solution message, and incoming backend event.
 ## Preconditions
 
 `VITE_BASE_URL` identifies the API prefix (normally `/api` via Nginx). JSON uses
-the backend's snake_case/casing strings. Authorization headers and one-use socket
-ticket are valid. Backend code is the operational source of truth.
+the backend's snake_case/casing strings. Authorization headers and the stored
+socket ticket value are valid. The ticket is intended for one use, but its
+backend read and clearing are not atomic. Backend code is the operational source
+of truth.
 
 ## Current behavior
 
@@ -92,7 +94,8 @@ changes, and recovery until a later query.
 
 RTK attaches current token and refreshes selected failures. Raw WebSocket URL is
 built with `ws:` even when the page/base may require `wss:`, risking mixed
-content. Ticket is one-use and backend stores a single connection per user.
+content. Ticket lookup then clearing is not an atomic consume operation, and the
+backend stores one process-local connection per user.
 Outgoing `SolutionUpdated` sends full snake_case payload with duel/task/language/
 solution; anti-cheat uses raw fetch and bypasses RTK refresh/status handling.
 
@@ -100,7 +103,9 @@ solution; anti-cheat uses raw fetch and bypasses RTK refresh/status handling.
 
 Queries tolerate repeats. Domain mutations generally have no client idempotency
 key. Events have no current replay ID/generation, so duplicates/stale messages
-cannot be reliably classified. Anti-cheat event UUIDs can support backend dedup.
+cannot be reliably classified. Anti-cheat UUIDs do not currently prevent
+duplicates because Duely neither looks up `EventId` before insert nor enforces a
+unique constraint.
 
 ## Ordering assumptions
 

--- a/docs/processes/backend-contracts.md
+++ b/docs/processes/backend-contracts.md
@@ -1,0 +1,161 @@
+# Backend contracts
+
+## Purpose
+
+Inventory the HTTP/WebSocket contracts consumed by Frontend and identify known
+field, event, validation, and cache-compatibility gaps against current backend.
+
+## Participants
+
+Frontend RTK/raw fetch/WebSocket parser, Duely controllers/DTOs/message sender,
+Taski task file routes, Exesh/Analyzer indirectly, Nginx base URL, and TypeScript
+or Superstruct models.
+
+## Entry points
+
+Every API query/mutation, token refresh, anti-cheat raw batch, task file fetch,
+ticket/socket open, outgoing solution message, and incoming backend event.
+
+## Preconditions
+
+`VITE_BASE_URL` identifies the API prefix (normally `/api` via Nginx). JSON uses
+the backend's snake_case/casing strings. Authorization headers and one-use socket
+ticket are valid. Backend code is the operational source of truth.
+
+## Current behavior
+
+HTTP route catalog from injected endpoints:
+
+| Domain | Methods and paths consumed |
+| --- | --- |
+| Auth/users | `POST /users/register`, `/users/login`, `/users/refresh`; `GET /users/iam`, `/users/{id}`, `/users/nickname/{nickname}`; `POST /users/ticket` |
+| Configurations | `GET/POST /duels/configurations`, `GET/PUT/DELETE /duels/configurations/{id}` |
+| Duels | `GET /duels/{id}`, `/duels?userId=`, `/duels/active`, `/groups/{id}/duels`; `POST /duels/search`, `/duels/cancel` |
+| Duel invitations | `GET/POST /duels/invitations`, `POST .../accept`, `.../deny`, `.../cancel`; `GET/POST /duels/group/invitations`, `POST .../accept`; `GET /duels/tournament/invitations`, `POST /tournaments/{id}/duels/accept` |
+| Groups | `GET/POST /groups`; `GET/PUT /groups/{id}`; `GET /groups/{id}/users`; `POST /groups/{id}/role`, `/groups/{id}/exclude`, `/groups/{id}/leave`; `GET/POST /groups/invitations`; `POST /groups/invitations/accept`, `/deny`, `/cancel` |
+| Tournaments | `GET /groups/{id}/tournaments`, `POST /tournaments`, `GET /tournaments/{id}`, `POST /tournaments/{id}/start` |
+| Tasks/runs | `GET /task/{id}`, `/task/{id}/{file}`, `/task/topics`; `POST /code-runs`, `GET /code-runs/{id}` |
+| Submissions | `POST/GET /duels/{id}/submissions`, `GET /duels/{id}/submissions/{submissionId}` |
+| Actions | `POST /actions` with `{ actions: [...] }` through raw authenticated fetch |
+
+Current incoming Duely message enum is `DuelStarted`, `DuelFinished`,
+`DuelChanged`, `OpponentSolutionUpdated`, `DuelInvitation`,
+`DuelInvitationCanceled`, `DuelInvitationDenied`, `SubmissionStatusUpdated`,
+`CodeRunStatusUpdated`, `GroupInvitation`, `GroupInvitationCanceled`,
+`GroupDuelInvitation`, `GroupDuelInvitationCanceled`, and
+`TournamentDuelInvitation`. Sender serializes flat polymorphic JSON with `type`
+and message fields; it does not currently include replay `lastEventId`.
+
+Frontend normalizes event/type/name and data/payload/flat envelopes, snake/camel
+cursor spellings, stringified payloads, and punctuation/case in event names, but
+casts payloads without runtime validation. It handles most duel/direct/group-
+membership/submission/tournament-invite events. It does not handle current
+`GroupDuelInvitation`, `GroupDuelInvitationCanceled`, or `CodeRunStatusUpdated`.
+It handles `DuelCanceled` and tournament-canceled aliases not emitted by the
+current backend. Code-run state is recovered by HTTP polling.
+
+Known DTO boundaries: login/register responses rely on TypeScript only; refresh
+token pair and task test files use Superstruct. Submission list uses
+`submission_id`, while create/detail uses `id`, and code adapts this explicitly.
+Frontend task model/UI focuses on `write_code`, a subset of Taski task types.
+Direct friendly invitations are queried/labeled with client type `Ranked`.
+
+## Client state transitions
+
+HTTP responses populate RTK and sometimes extra reducers. WebSocket events
+patch/invalidate existing state. Without version/event ID, transition ordering
+is arrival-based. Contract mismatches typically become ignored events, undefined
+fields, stale cache, wrong matching, or render/request errors.
+
+## Backend state assumptions
+
+Duely owns identity/domain DTOs and emits browser events. Taski serves task
+packages/files and derives judging through Duely; browser does not consume
+Taski/Exesh status histories directly. Analyzer consumes persisted actions after
+duel completion, not browser responses.
+
+## State ownership
+
+Backend schemas/event definitions own wire truth. Frontend TypeScript types are
+compile-time consumer projections; Superstruct schemas provide runtime truth
+only where called. Documentation records current compatibility, not permission
+to change either side independently.
+
+## UI effects
+
+Compatible payloads render normal pages. Unknown events are silent; malformed
+JSON warns; structurally malformed known payloads can create stale/incorrect UI.
+Missing event handling delays invitations, code-run state, tournament/group
+changes, and recovery until a later query.
+
+## Network effects
+
+RTK attaches current token and refreshes selected failures. Raw WebSocket URL is
+built with `ws:` even when the page/base may require `wss:`, risking mixed
+content. Ticket is one-use and backend stores a single connection per user.
+Outgoing `SolutionUpdated` sends full snake_case payload with duel/task/language/
+solution; anti-cheat uses raw fetch and bypasses RTK refresh/status handling.
+
+## Idempotency and duplicate handling
+
+Queries tolerate repeats. Domain mutations generally have no client idempotency
+key. Events have no current replay ID/generation, so duplicates/stale messages
+cannot be reliably classified. Anti-cheat event UUIDs can support backend dedup.
+
+## Ordering assumptions
+
+The client assumes several HTTP successes precede their corresponding events.
+The backend flat payload is accepted by the parser, but the optional cursor path
+is currently inert. No schema revision or entity revision orders HTTP and socket
+representations.
+
+## Failure handling
+
+HTTP status handling varies by feature. Refresh and task-test validation are
+explicit; most DTOs are trusted. Unknown event names are ignored and reconnect
+does not replay missed events. Contract changes can therefore fail silently
+rather than fail closed with observable telemetry.
+
+## Reload and multiple tabs
+
+Each tab reopens with a fresh RTK cache and ticket. Backend's single connection
+per user conflicts with Frontend's per-tab manager. No cursor is sent on open,
+and stored `lastEventId` is not populated by current messages, so reload/tab
+replacement cannot replay the gap.
+
+## Implementation references
+
+- `src/shared/api/api.ts` and all injected `*Api.ts` files
+- frontend model/type files and Superstruct definitions
+- `src/features/duel-session/api/duelSessionApi.ts`
+- `src/features/anti-cheat`
+- Backend Duely controllers/DTOs/WebSocket message enum/sender
+- Backend Taski HTTP/task domain and Analyzer action schemas
+
+## Test coverage
+
+- **Existing frontend contract tests/MSW:** none.
+- **Needed consumer/provider tests:** every route method/body/response/error,
+  snake_case/string enums, optional/null fields, every WebSocket event, task types.
+- **Needed E2E:** Nginx HTTP/HTTPS socket URL, ticket reuse/replacement, refresh,
+  missed events/reconnect, real Taski files, judging, and action ingestion.
+
+## Current guarantees
+
+Listed paths and current common DTO casing match normal source paths; the parser
+accepts current flat Duely events; backend re-authorizes operations; refresh token
+and task-test payloads have runtime validation; browser is isolated from direct
+Exesh execution.
+
+## Open questions
+
+Schema/version governance, complete event envelope/cursor, secure socket URL,
+multi-tab connection policy, task-type compatibility, runtime validation scope,
+and mutation idempotency require cross-repository decisions.
+
+## Proposed requirements
+
+Publish versioned OpenAPI/event schemas and generate/validate consumers; add
+provider/consumer contract tests; handle every enum member exhaustively; include
+event/entity revisions and invitation IDs; use `wss:` under HTTPS; align tags and
+document backward-compatible rollout order.

--- a/docs/processes/client-state-ownership.md
+++ b/docs/processes/client-state-ownership.md
@@ -1,0 +1,148 @@
+# Client state ownership
+
+## Purpose
+
+Catalog every durable and ephemeral client state so changes have explicit
+owners, reset triggers, reload behavior, tab scope, and reconciliation rules.
+
+## Participants
+
+Redux slices, redux-persist/localStorage, RTK Query, component state,
+sessionStorage hooks, browser URL/history, Duely/Taski, pages/widgets, and tabs.
+
+## Entry points
+
+Store creation/rehydration, query/mutation/event, user interaction, navigation,
+reload, logout, tab duplication/open, cache eviction, and backend refetch.
+
+## Preconditions
+
+Same-origin browser storage is available; otherwise storage hooks silently keep
+memory state and redux-persist may fall back/error according to library behavior.
+
+## Current behavior
+
+| State | Owner/source of truth | Storage/lifetime | Reset trigger | Reload / tab behavior | Main stale risk |
+| --- | --- | --- | --- | --- | --- |
+| auth user/access/refresh | Duely, cached client | persisted Redux | logout/new responses | reload yes; shared storage, independent tab state | invalid/old token/user, cross-user cache |
+| `activeDuelId`, `phase`, `lastEventId`, search matching, canceled dialog | backend-derived/client workflow | persisted duelSession | reset/idle/logout/events | reload/shared storage; no live sync | persisted search/active mismatch |
+| `sessionInterrupted`, task snapshots, opened keys/status flag | client manager | unpersisted Redux | socket open/session reset/modal | lost on reload, tab-local | missed notifications |
+| own code/language by `${duelId}:${taskId}` | local draft, overwritten by Duel response | persisted codeEditor | logout only | reload/shared storage, independent writers | backend fetch overwrite/cross-tab race |
+| opponent code/language | backend socket/Duel response | unpersisted codeEditor | session/code not fully pruned | lost reload then refetch | stale if event/cache missed |
+| RTK Query cache | latest received HTTP/manual patch | API Redux only | eviction/invalidation/app reload | lost reload, tab-local | old-user/missed-event/filter divergence |
+| route and task selection | URL/browser history | pathname + `?task=` | navigation | survives copied URL; browser history | locked/changed task fallback |
+| Home forms/modals/config/waiting/pending IDs | UI | sessionStorage | selected handlers/phase changes | reload same tab; not user-scoped | stale modal/disabled action |
+| code panel `my/opponent` tab | UI | sessionStorage per duel ID | manual/privacy effect | same tab reload | cross-user stale selection |
+| run input/draft/run status | UI | sessionStorage per duel/task | new run/manual edit | same tab reload | stale `running`, no run ID |
+| result dismissed | UI preference | localStorage per duel ID | user closes; never globally | shared tabs/users | one user hides another's dialog |
+| local configuration copy | feature UI | `duel-configurations` localStorage | local create/update/delete | shared/unversioned | diverges from backend |
+| auth/group/tournament forms/modals | component except Home | React state | unmount/close | lost reload/tab-local | partial request ambiguity |
+| theme | client preference | persisted Redux | toggle | shared storage, independent tab state | last-writer wins |
+| anti-cheat queue/sequence/flush flag | browser process | module memory | successful/failed/disabled flush, token loss, reload | lost reload, per tab | silent loss/duplicate stream IDs |
+
+Persist whitelists are exact: auth (`user`, `token`, `refreshToken`), duelSession
+(`activeDuelId`, `lastEventId`, `phase`, `searchNickname`,
+`searchConfigurationId`, `searchInvitationType`, `searchTournamentId`,
+`duelCanceled`, `duelCanceledOpponentNickname`), codeEditor
+(`codeByTaskKey`, `languageByTaskKey`), theme (`mode`). All are version 1 with no
+configured migration. RTK Query and opponent/snapshot/interrupted state are not
+persisted.
+
+## Client state transitions
+
+State changes are process-specific. The important ownership transition is
+`backend response/event -> RTK/Redux snapshot -> optional local persistence`;
+reload reverses it as `localStorage -> Redux provisional state -> selective
+backend refetch`. Component/sessionStorage state is not globally reconciled.
+
+## Backend state assumptions
+
+Backend is authoritative for user, duel, invitation, group, tournament,
+submission, tasks, and permissions. Persisted Redux/browser UI is a cache. Some
+states are checked (`getMe`, `getActiveDuel`, `getDuel`); searching, forms,
+submission caches, and configuration local copies can remain unsynchronized.
+
+## State ownership
+
+| State | Owner/source of truth | Redux | RTK Query | local state | sessionStorage | localStorage | Survives reload |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Auth | Duely | Yes | getMe | No | No | `persist:auth` | Yes |
+| Duel session workflow | Duely + client | Yes | duel queries | No | waiting flag separate | `persist:duelSession` | Partial |
+| Editor | client/backend snapshot | Yes | Duel supplies solution | Monaco mirror | code tab/run separate | `persist:codeEditor` | Own code yes |
+| Groups/tournaments/submissions | Duely | API reducer | Yes | forms | Home only | No | No cache |
+| Theme | client | Yes | No | No | No | `persist:theme` | Yes |
+
+## UI effects
+
+Pages render a mixture of sources: persisted phase drives Home immediately,
+RTK data drives domain lists/details, local state controls forms/modals, and URL
+drives duel task/tab routes. These can disagree until a query/event/effect wins;
+some disagreements have no visible recovery control.
+
+## Network effects
+
+Redux workflow fields do not automatically call backend. RTK subscriptions
+fetch on mount/invalidation. Manual WebSocket patches touch existing cache only.
+Storage writes cause no network reconciliation and no cross-tab Redux action.
+
+## Idempotency and duplicate handling
+
+Persistence is last-write-wins. Reducers generally tolerate repeated assignments
+but workflow events have no IDs. RTK cache keys separate endpoint args. Browser
+form/pending flags are not idempotency keys and cannot prove backend outcome.
+
+## Ordering assumptions
+
+Rehydration precedes UI, but backend reconciliation can complete after several
+components act on persisted state. Debounced editor writes, Duel refetches,
+socket events, localStorage writes, and other-tab actions have no total order.
+
+## Failure handling
+
+Custom hooks catch parse/write errors and use initial/memory value; no user
+warning or migration. Redux/cache conflicts remain until reset/refetch. Storage
+quota can silently prevent new writes. Sensitive tokens/source code remain in
+localStorage when not explicitly cleared.
+
+## Reload and multiple tabs
+
+Reload restores whitelisted state and per-tab sessionStorage, but not RTK cache,
+opponent code, task snapshots, or anti-cheat queue. Tabs share localStorage
+bytes, not live Redux; sessionStorage is independent. Concurrent persist writes
+can overwrite logout, tokens, code, theme, and phase.
+
+## Implementation references
+
+- `src/app/store.ts`
+- Slice type/reducer files in `features/auth`, `features/duel-session`,
+  `widgets/code-panel`, `features/theme`
+- `src/shared/lib/use{Local,Session}Storage.tsx`
+- Home, DuelInfo, CodePanel, TaskDescription call sites
+- `src/shared/api/api.ts`
+
+## Test coverage
+
+- **Existing tests/MSW:** none.
+- **Needed unit/integration:** every whitelist/reset, corrupt/versioned storage,
+  code/server conflict, session-key hydration, cache isolation, queue lifetime.
+- **Needed browser/E2E:** reload at every phase, logout/login another user,
+  storage quota/corruption, two-tab last-writer races, stale forms/run state, and
+  missed-event reconciliation.
+
+## Current guarantees
+
+PersistGate completes before child render; only listed fields persist; editor
+logout reducer returns empty maps; RTK cache and anti-cheat queue do not survive
+reload; sessionStorage hooks isolate keys per tab under normal browser behavior.
+
+## Open questions
+
+Required retention/user scoping, conflict winners, schema migrations, tab
+coordination, sensitive-storage policy, and cleanup after duel completion remain
+undefined.
+
+## Proposed requirements
+
+Give every persisted key a schema/migration/user scope/TTL/reset policy; treat
+backend reconciliation as explicit state; atomically purge user data; coordinate
+tabs; version editor/session formats; and test storage/reload/conflict matrices.

--- a/docs/processes/duel-invitations.md
+++ b/docs/processes/duel-invitations.md
@@ -1,0 +1,157 @@
+# Duel invitations
+
+## Purpose
+
+Document direct friendly, group-membership, group-duel, and tournament-duel
+invitations, including the distinct acceptance and cancellation semantics.
+
+## Participants
+
+Home panels, group pages, invitation RTK endpoints, duel-session Redux,
+sessionStorage waiting fields, Duely HTTP/WebSocket producers, invitee/inviter,
+group managers, and tournament scheduler.
+
+## Entry points
+
+Create a friendly invitation, receive/open invitation lists, accept or deny,
+accept group membership, accept a group/tournament duel, cancel from another
+client, reload Home, and receive invitation WebSocket messages.
+
+## Preconditions
+
+The user is authenticated. Duely verifies users, roles, group membership,
+configuration access, tournament state, and whether an invitation remains
+pending. UI visibility is not authorization.
+
+## Current behavior
+
+Direct creation calls `POST /duels/invitations`; on success the sender persists
+opponent/configuration/type `Friendly` and enters searching. Home queries direct
+pending invitations using argument `Ranked`, although the backend domain calls
+them friendly; its transform labels the returned item `Ranked`. Direct accept,
+group-duel accept, and tournament accept wait for HTTP success, persist selected
+matching fields, set Home's `waitingForStart`, and wait for `DuelStarted`.
+Only direct invitations expose deny on Home. Group membership accept/deny updates
+membership caches but accept does not navigate to the group.
+
+```mermaid
+sequenceDiagram
+    participant A as Inviter
+    participant D as Duely
+    participant B as Invitee Home
+    participant S as duelSession
+    A->>D: POST /duels/invitations
+    D-->>B: DuelInvitation + list invalidation
+    B->>D: Accept invitation
+    D-->>B: Success
+    B->>S: Store opponent/config/type; searching
+    D-->>B: DuelStarted
+    B->>S: Store duel; active
+    alt Deny/cancel
+        B->>D: Deny direct invitation
+        D-->>A: denied/canceled event
+        A->>S: Reset only if persisted fields match
+    end
+```
+
+## Client state transitions
+
+Create/accept moves `idle -> searching`; `DuelStarted` moves to `active`.
+Cancellation/denial returns to idle only when event nickname/configuration and,
+for tournaments, tournament ID match persisted fields. Group acceptance does
+not persist group ID/type, so otherwise-identical group invitations are
+ambiguous. The HTTP/event ordering race is the same as ranked matchmaking.
+
+## Backend state assumptions
+
+Duely is authoritative for pending invitations and creates the duel. Direct,
+group-duel, tournament-duel, and group-membership invitations are separate
+domain concepts even when the UI aggregates them. A generic backend tournament
+accept cancellation message lacks `tournament_id`, so the frontend's tournament
+matching rule may not reset the inviter.
+
+## State ownership
+
+Invitation lists are RTK snapshots. Pending outgoing/accepted matching values
+are persisted in duelSession. Home panel visibility, pending nickname/ID, and
+`waitingForStart` are sessionStorage values, not backend facts and not
+user-scoped. Duely owns invitation existence and acceptance.
+
+## UI effects
+
+Home aggregates direct, group-duel, tournament-duel, and group-membership cards.
+Forms/panels disable or display pending state using local/session values. A
+stale pending nickname or group invitation ID can keep controls disabled after
+reload. Group/tournament duel invitations offer accept but no symmetric deny in
+the current UI.
+
+## Network effects
+
+RTK mutations create/accept/deny invitations. WebSocket invitation events mostly
+invalidate lists. Current frontend handlers do not recognize backend
+`GroupDuelInvitation` or `GroupDuelInvitationCanceled`, so those list changes can
+remain invisible. Tournament invitation events invalidate duel-invitation data,
+not the tournament bracket/detail.
+
+## Idempotency and duplicate handling
+
+No action sends a client idempotency key. Some buttons use mutation loading,
+but repeated clicks or multiple tabs can submit the same accept/deny. Backend
+must reject or make repeated transitions safe. Repeated list invalidation is
+safe; repeated session events are not generation-checked.
+
+## Ordering assumptions
+
+Acceptance assumes HTTP success arrives before `DuelStarted`. Cancellation
+matching assumes stored fields already describe that invitation. Events arriving
+before local state, after another invitation starts, or without matching fields
+can be ignored or reset the wrong flow.
+
+## Failure handling
+
+HTTP errors remain local; `409` has special friendly-create messaging. A lost
+success response can leave a backend-accepted invitation while UI remains idle.
+Unknown/unhandled WebSocket events are silently ignored. No reconciliation step
+fetches the accepted pending duel workflow after every reconnect.
+
+## Reload and multiple tabs
+
+Persisted matching survives reload and is shared through localStorage bytes;
+Home waiting/panel flags survive only in the same tab's sessionStorage. Tabs do
+not broadcast accepted/canceled state. Old session keys survive logout and can
+be presented to another user in the same tab.
+
+## Implementation references
+
+- `src/pages/home/ui/HomePage.tsx`
+- invitation APIs under `src/entities/duel-invitation`
+- group invitation and group-duel APIs under `src/entities/group`
+- tournament API under `src/entities/tournament`
+- `src/features/duel-session/api/duelSessionApi.ts`
+
+## Test coverage
+
+- **Existing tests:** none.
+- **Needed integration:** all four invitation families, exact event types/fields,
+  accept/event order permutations, duplicate accepts, cancellation matching.
+- **Needed E2E:** inviter/invitee browsers, reload and logout during wait,
+  two same-opponent invitations, group/tournament updates, and two tabs.
+
+## Current guarantees
+
+Normal successful direct create/accept records enough fields to match direct
+cancel/deny; direct list mutations invalidate their cache; backend remains the
+authorization boundary; `DuelStarted` can activate an accepted duel.
+
+## Open questions
+
+Invitation type vocabulary, a common invitation ID, group ID in cancellation,
+deny behavior for every family, expiration, post-accept navigation, and
+cross-tab ownership require an explicit contract.
+
+## Proposed requirements
+
+Use a versioned discriminated invitation payload with immutable ID/type/context;
+support idempotent accept/deny/cancel; handle every backend event; reconcile
+pending state on load/reconnect; and remove identity from ad hoc nickname fields.
+

--- a/docs/processes/duel-page-and-task-navigation.md
+++ b/docs/processes/duel-page-and-task-navigation.md
@@ -1,0 +1,134 @@
+# Duel page and task navigation
+
+## Purpose
+
+Describe duel-route authorization, nested pages, task selection, sequential
+task visibility, participant/spectator UI, and navigation recovery.
+
+## Participants
+
+Router, DuelPage split layout, CodePanel, TaskPanel/description/submissions,
+DuelInfo, duel/task RTK APIs, duelSession snapshots, authenticated user, Duely,
+and Taski-served task artifacts.
+
+## Entry points
+
+`/duel/:duelId`, nested description/submissions/detail routes, `?task=<key>`,
+session navigation, group/tournament duel links, browser reload/back/deep link,
+and `DuelChanged`/`DuelFinished` events.
+
+## Preconditions
+
+The route ID must be numeric and the backend must allow viewing. Tasks come from
+the duel DTO; task content/files are fetched from Taski-facing endpoints.
+Participants and spectators receive different editing/submission capabilities.
+
+## Current behavior
+
+DuelPage validates a finite numeric ID for its own query and shows special
+`403` output. Other errors/invalid IDs can still render child panels; child
+queries can call `/duels/NaN` because their skip condition checks only a nonempty
+string. Nested index redirects to description while preserving task selection.
+Tasks sort by key. `?task` selects a valid visible task; invalid/missing selection
+is replaced with the first, and legacy `task_id` falls back to key `A`. A task
+with null ID is locked. Participant status controls write/run/submit and
+anti-cheat enabling; spectator UI is read-only, while backend remains authority.
+
+## Client state transitions
+
+The URL owns task/child-page choice. On each duel response, duelSession compares
+current tasks with unpersisted `lastTasksByDuelId`. The first snapshot creates no
+alert; a later `null -> id` marks newly opened task keys and raises
+`duelStatusChanged`. Removing/changing tasks has no equivalent alert. Result and
+opened-task modals have separate dismissal state.
+
+## Backend state assumptions
+
+Duely owns viewer access, participant identity, privacy, duel status/result,
+task plan and visible solutions. Taski owns task statement/files/types. Frontend
+models only the `write_code` task path although Taski supports additional task
+types; unsupported DTOs need an explicit compatibility rule.
+
+## State ownership
+
+Backend duel/task DTOs are RTK cache truth for the rendered page. URL owns
+navigation. Unpersisted duelSession owns task-opening comparison. localStorage
+`duel:{id}:resultDismissed` owns result-modal preference; editor/run/panel state
+has separate documented owners.
+
+## UI effects
+
+The split view renders code and task panes. Spectators cannot edit/run/submit
+and cannot open submission detail, though they can view submission lists/authors.
+Newly opened tasks can raise DuelInfo modal. Result dismissal is shared across
+users/tabs due to an unscoped localStorage key.
+
+## Network effects
+
+Parent and child components fetch duel, task, statement, visible test files, and
+submission data based on route/task. `DuelChanged` invalidates or patches duel
+data; `DuelFinished` invalidates duel/user. Invalid route propagation can issue
+malformed requests before an error boundary/response resolves.
+
+## Idempotency and duplicate handling
+
+Repeated navigation/query is RTK-deduplicated per cache key. Task snapshot
+reducers use key sets to avoid repeating opened alerts in one runtime. Reload
+loses those sets, and first fetched snapshot intentionally suppresses alerts.
+
+## Ordering assumptions
+
+URL normalization assumes task list is loaded. Duel responses can arrive around
+navigation and editor debounce. A refetched duel can overwrite locally persisted
+solution/language before later editor state writes. Task-opening detection
+depends on observing both old and new snapshots in one tab runtime.
+
+## Failure handling
+
+`403` has explicit UI; other parent errors are not uniformly terminal for child
+rendering. Missing task ID produces locked UI. Task/file errors render local
+loading/error states. There is no general route-level recovery from deleted
+duels, unsupported task types, or stale persisted active session.
+
+## Reload and multiple tabs
+
+Reload restores route/task and code, loses RTK cache/task snapshots, and treats
+the first current task set as baseline. Result dismissal is shared localStorage;
+selected code tab/run state is sessionStorage. Tabs may observe different duel
+versions and task-opening alerts.
+
+## Implementation references
+
+- `src/app/router/router.tsx`
+- duel page under `src/pages/duel`
+- `src/widgets/code-panel`
+- task panel/description/submission widgets and task entity API
+- `src/features/duel-session/model/duelSessionSlice.ts`
+
+## Test coverage
+
+- **Existing tests:** none.
+- **Needed integration:** invalid/forbidden/deleted IDs, task query normalization,
+  task open transitions, task DTO variants, participant/spectator capabilities.
+- **Needed E2E:** all nested/deep routes, reload/back, sequential task opening,
+  result modal scoping, task errors, spectator attempts, and two tabs.
+
+## Current guarantees
+
+A valid accessible duel normally renders its current backend tasks; a valid task
+query is shareable; editing controls are hidden/readonly for known spectators;
+the backend still decides access; first-load task snapshot does not falsely
+announce every already-open task.
+
+## Open questions
+
+Canonical invalid-route handling, unsupported task types, sequential-change
+revision, modal scoping, spectator submission policy, and post-finish navigation
+are not explicit contracts.
+
+## Proposed requirements
+
+Validate route IDs once before rendering children; version/validate duel/task
+DTOs; make task opening an explicit backend event/revision; scope preferences by
+user; and test route, permission, reload, and task-type matrices.
+

--- a/docs/processes/duel-session-lifecycle.md
+++ b/docs/processes/duel-session-lifecycle.md
@@ -1,0 +1,171 @@
+# Duel session lifecycle
+
+## Purpose
+
+Coordinate local `idle`, `searching`, and `active` UI workflow with backend
+pending/active duels across HTTP, socket events, logout, disconnect, and reload.
+
+## Participants
+
+Duel-session slice/thunk/manager/button, Home/Group pages, RTK duel endpoints,
+redux-persist, WebSocket handlers, router, and Duely pending/active duel state.
+
+## Entry points
+
+Start/accept/cancel click, `DuelStarted`/finished/canceled/invitation events,
+`getActiveDuel` response, reload/browser reopen, direct duel URL, socket close,
+logout, or persisted rehydration.
+
+## Preconditions
+
+Authenticated user for backend operations. `searching` should correspond to a
+backend pending state; `active`/ID should correspond to an InProgress duel, but
+reducers do not enforce these invariants.
+
+## Current behavior
+
+Exact phases are `idle`, `searching`, `active`. `setPhase("idle")` clears active
+ID, matching fields, and task snapshots; other values do not validate required
+fields. `setActiveDuelId(non-null)` changes searching/idle to active, clears
+matching/task notification state; null clears event/task state but does not
+itself set phase.
+
+`resetDuelSession` clears every field including unpersisted interrupted/task
+state. Logout manager invokes it. Socket close resets searching to idle and
+marks interrupted; finish resets before invalidating duel/user. Direct duel
+route does not set phase/ID.
+
+Home subscribes to `getActiveDuel`. Fulfillment writes `activeDuelId` but the
+extra reducer merely calls `restoreDuelSession(...)` as a function, creating a
+thunk action object that is not dispatched. Manager later dispatches restore
+only when `user && activeDuelId && phase==idle`; it GETs the duel and sets active
+only if `InProgress`, otherwise resets. If persisted phase is already active or
+searching, that manager check does not run. A 404 active query resets only when
+phase is currently active.
+
+On Navigation Timing `reload`, manager converts persisted searching/no active ID
+to idle without calling cancel. Browser reopen/history navigation is not treated
+as reload. Navigation from searching to active happens only in mounted Home
+waiting effect or DuelSessionButton; events received on another page only update
+Redux.
+
+```mermaid
+sequenceDiagram
+    participant B as Browser reload
+    participant S as persisted duelSession
+    participant M as Manager
+    participant H as Home/getActiveDuel
+    participant D as Duely
+    B->>S: rehydrate phase/activeDuelId
+    S-->>M: provisional session
+    alt phase idle + activeDuelId
+        M->>D: GET /duels/:id via restore thunk
+        D-->>M: InProgress/finished/error
+        M->>S: active or reset
+    else Home mounted
+        H->>D: GET /duels/active
+        D-->>H: active or 404
+        H->>S: set ID; reducer's thunk call is not dispatched
+    end
+```
+
+## Client state transitions
+
+- Ranked/friendly/accept success: `idle -> searching`.
+- `DuelStarted`: `idle|searching -> active`, non-null active ID.
+- cancel success/socket close while searching: `searching -> idle`.
+- finish/logout/reset: `active|searching|idle -> idle`, ID null.
+- `getActiveDuel` can create `phase unchanged + activeDuelId non-null`, including
+  inconsistent `searching + ID`.
+
+## Backend state assumptions
+
+Backend pending types and active Duel are authoritative. `GET /duels/active` and
+`GET /duels/:id` are partial reconciliation. Disconnect cancels pending states.
+No endpoint verifies "searching" directly, and persisted matching fields are
+not compared with backend pending rows.
+
+## State ownership
+
+| State | Owner/source of truth | Redux | RTK Query | local state | sessionStorage | localStorage | Survives reload |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Pending/search | Duely; client phase cache | duelSession | invitation lists | No | waiting flag | `persist:duelSession` | Yes, conditionally reset |
+| Active duel | Duely | ID/phase | active/detail | No | No | persisted ID/phase | Yes |
+| Matching fields | client correlation | duelSession | invitation DTOs | No | No | persisted | Yes |
+| Interrupted/task notifications | client | duelSession | Duel data | manager/modals | No | Not whitelisted | No |
+
+## UI effects
+
+Home shows idle controls or search loader; session button starts/cancels/navigates.
+Canceled/denied opens modal. Active event can navigate only where workflow effects
+are mounted. Direct active/finished pages render independently of phase. Socket
+close can show idle Home plus blocking interruption modal.
+
+## Network effects
+
+Start/cancel/accept mutations precede most local phase changes. Manager/ Home
+perform active/detail GETs. Socket events invalidate duel data. No pending-state
+polling, replay, or automatic post-close socket reconnect exists.
+
+## Idempotency and duplicate handling
+
+Repeated assignments are syntactically allowed, but duplicate/old events are
+not identified. Multiple HTTP requests can create/cancel competing backend
+state. Reset is idempotent locally. Persisted state has no generation/user ID.
+
+## Ordering assumptions
+
+HTTP mutation success is assumed before related socket event. Early start can
+be overwritten by later `setPhase(searching)`. Finish is assumed to concern the
+current active duel. Home navigation assumes phase transition occurs after the
+watcher mounts.
+
+## Failure handling
+
+Mutation errors generally leave prior phase. Lost success response leaves
+backend changed/local unchanged. Missed start leaves searching; missed finish
+leaves active. A stale active ID may be repaired only in specific Home/idle/404
+paths. Searching can exist indefinitely after browser reopen.
+
+## Reload and multiple tabs
+
+ID/phase/matching persist in shared localStorage; each tab has independent Redux
+and socket. Reload searching resets local idle, while backend old-socket cleanup
+also cancels pending. Browser reopen may retain stale search. One tab's start/
+finish/logout does not update another except through backend events/storage races.
+
+## Implementation references
+
+- `src/features/duel-session/model/{duelSessionSlice,thunks,types}.ts`
+- `src/features/duel-session/ui/{DuelSessionManager,DuelSessionButton}`
+- `src/pages/home/ui/HomePage.tsx`
+- `src/entities/duel/api/duelApi.ts`
+- Backend docs: `../../../Backend/docs/processes/duel-lifecycle.md`
+
+## Test coverage
+
+- **Existing tests/MSW:** none.
+- **Needed unit/integration:** every reducer invariant, ineffective thunk call,
+  active query/restore matrix, duplicate/out-of-order events, early start.
+- **Needed browser/E2E:** all three phases, reload/reopen/direct URL, response
+  loss, missed start/finish, logout/disconnect, active event on other page, and
+  two tabs.
+
+## Current guarantees
+
+Only three phase strings compile; whitelisted session fields survive reload;
+non-null active ID via its reducer promotes idle/searching to active; reset
+clears all session fields; Home supplies the only active-duel query on its mount.
+
+## Open questions
+
+Phase invariants, global navigation, pending reconciliation, restore trigger,
+browser-reopen behavior, event relevance, and multi-tab authority are undefined.
+
+## Proposed requirements
+
+Represent backend-verified session generation/type; reconcile active and pending
+state globally after rehydration/reconnect; dispatch restore correctly; make
+transitions event/order safe; navigate by an explicit global policy; and test
+every persisted/inconsistent state.
+

--- a/docs/processes/duel-session-lifecycle.md
+++ b/docs/processes/duel-session-lifecycle.md
@@ -140,7 +140,7 @@ finish/logout does not update another except through backend events/storage race
 - `src/features/duel-session/ui/{DuelSessionManager,DuelSessionButton}`
 - `src/pages/home/ui/HomePage.tsx`
 - `src/entities/duel/api/duelApi.ts`
-- Backend docs: `../../../Backend/docs/processes/duel-lifecycle.md`
+- CoDuels-Backend: `docs/processes/duel-lifecycle.md`
 
 ## Test coverage
 
@@ -168,4 +168,3 @@ Represent backend-verified session generation/type; reconcile active and pending
 state globally after rehydration/reconnect; dispatch restore correctly; make
 transitions event/order safe; navigate by an explicit global policy; and test
 every persisted/inconsistent state.
-

--- a/docs/processes/editor-state-and-code-sync.md
+++ b/docs/processes/editor-state-and-code-sync.md
@@ -1,0 +1,156 @@
+# Editor state and code sync
+
+## Purpose
+
+Describe Monaco draft ownership, language mapping, server-solution hydration,
+privacy-based opponent view, and WebSocket solution synchronization.
+
+## Participants
+
+CodePanel/Monaco, codeEditor persisted Redux slice, duel/task RTK cache,
+duel-session interval, authenticated participant/spectator, opponent, Duely
+WebSocket/use cases, and browser tabs.
+
+## Entry points
+
+Open/switch task, type/delete/paste/cut/change language, load/refetch a duel,
+switch my/opponent tab, receive `OpponentSolutionUpdated`, reload/logout, finish
+duel, reconnect, or edit from another tab.
+
+## Preconditions
+
+A valid duel/task is loaded. Participant/status/privacy determines allowed UI.
+Client language values `cpp`, `go`, `python` map to API values `Cpp`, `Golang`,
+`Python`. Duely performs final participant/status/privacy authorization.
+
+## Current behavior
+
+Own code/language is stored under `${duelId}:${taskId}` and persisted. Monaco
+keeps local state and debounces Redux updates for 500 ms. `getDuel.fulfilled`
+hydrates solutions and can overwrite an existing persisted draft; a pending
+debounce may then overwrite that response. Opponent values are unpersisted.
+The selected `my/opponent` tab is sessionStorage key `duel.{duelId}.codeTab` and
+privacy forces `my` when opponent view is unavailable. Read-only mode also
+blocks copy/cut/context menu.
+
+Every second, the session manager chooses active/route duel and selected/first
+task, reads code/language, requires an open socket and cached duel privacy, and
+sends a full `SolutionUpdated` payload when different from one `lastSent` value.
+It does not explicitly require participant identity, active phase, or unfinished
+status; backend rejects invalid sends. Incoming opponent updates require a
+privacy-enabled cached duel, map task key to ID, and update opponent state.
+
+```mermaid
+sequenceDiagram
+    participant E as Monaco
+    participant R as persisted codeEditor
+    participant Q as Duel RTK cache
+    participant W as WebSocket interval
+    participant D as Duely
+    E->>R: Debounced own code/language (500 ms)
+    Q->>R: getDuel solution hydration/refetch
+    Note over R: Last reducer/write wins
+    loop Every 1 second
+        W->>R: Read selected task draft
+        W->>D: SolutionUpdated(full code) if changed/open/privacy
+    end
+    D-->>W: OpponentSolutionUpdated
+    W->>R: Store unpersisted opponent code
+```
+
+## Client state transitions
+
+Typing changes Monaco immediately and Redux later. Task switch changes the key
+and causes the interval to resend that task because `lastSent` is a single
+payload. Logout empties own/opponent maps. Duel finish does not prune code. A
+Duel refetch can replace own code/language with backend solution state.
+
+## Backend state assumptions
+
+Duely owns the latest accepted synchronized solution and enforces user, duel,
+task-key, privacy, participant, and status rules. The client assumes one-character
+task keys and compatible language strings. WebSocket synchronization is not an
+authoritative save acknowledgement.
+
+## State ownership
+
+The active local draft is client-owned until a backend response/refetch is
+applied; current code has no explicit conflict policy. Persisted Redux stores own
+drafts, unpersisted Redux stores opponent drafts, RTK stores received duel
+solutions, Monaco mirrors the selected draft, and Duely owns accepted shared data.
+
+## UI effects
+
+Participants can edit while eligible; spectators/opponent tab are readonly.
+Privacy controls whether opponent tab is offered. There is no visible dirty,
+syncing, acknowledged, rejected, or conflict indicator, so a user cannot tell
+whether the latest edit reached Duely.
+
+## Network effects
+
+The interval sends the entire solution, not deltas, over the authenticated
+socket. Switching task/language resends. Last edits made just before close may
+never be sent. Incoming updates patch Redux only, not RTK duel solutions.
+
+## Idempotency and duplicate handling
+
+Identical consecutive payloads in one manager instance are suppressed by
+`lastSent`. There is no message ID/version/acknowledgement; reconnect/remount/task
+switch may resend. Backend must tolerate duplicate full-state updates. Two tabs
+can alternately overwrite the same solution.
+
+## Ordering assumptions
+
+Local debounce, HTTP duel hydration, one-second socket send, opponent events,
+and other tabs are unordered. The code implicitly uses arrival/last-write wins,
+without revision comparison. An incoming update can target any cached private
+duel/task and is not checked against the current route/active ID.
+
+## Failure handling
+
+Closed socket skips sends without durable queue. Backend rejection is not shown.
+Reload preserves own draft but loses last-sent/opponent state; next eligible
+interval can resend. Malformed/unknown task updates are ignored. No final flush
+is guaranteed on navigation or unload.
+
+## Reload and multiple tabs
+
+Own code/language survives in shared localStorage, but each tab has independent
+Redux/Monaco state and persist writes. Opponent state and sync marker disappear.
+Tabs do not listen for storage changes and can overwrite each other's draft and
+backend solution. Logout in one tab is not an atomic purge in the others.
+
+## Implementation references
+
+- codeEditor slice and CodePanel under `src/widgets/code-panel`
+- `src/features/duel-session/api/duelSessionApi.ts`
+- duel API `getDuel` hydration reducer
+- Monaco action tracking hooks under anti-cheat features
+- Duely solution-update WebSocket handler/use case
+
+## Test coverage
+
+- **Existing tests:** none.
+- **Needed unit/integration:** language mapping, debounce/refetch order, privacy,
+  task switch, duplicate suppression, invalid event/task, logout cleanup.
+- **Needed E2E:** edit/reload/offline/close, two tabs/users, spectator attempts,
+  opponent updates, backend rejection, duel finish, and reconnect conflicts.
+
+## Current guarantees
+
+Own keyed drafts normally survive reload and clear on local logout; normal
+private participant sessions send changed full solutions at most once per
+interval; backend remains the security boundary; opponent data is not persisted.
+
+## Open questions
+
+Conflict winner, save acknowledgement/revision, retention after duel, cross-tab
+ownership, final-flush expectation, copying restrictions, and precise privacy
+semantics need explicit product requirements.
+
+## Proposed requirements
+
+Define versioned server/client solution revisions and acknowledgements; gate
+sends by verified participant/status; scope/prune encrypted or safer persistence;
+coordinate tabs; preserve unsent drafts; expose sync state; and test all races.
+

--- a/docs/processes/failure-handling.md
+++ b/docs/processes/failure-handling.md
@@ -1,0 +1,139 @@
+# Failure handling
+
+## Purpose
+
+Consolidate degraded-path behavior across bootstrap, authentication, HTTP cache,
+WebSocket, duel workflows, storage, editor, judging, and anti-cheat delivery.
+
+## Participants
+
+ErrorBoundary/Fallback/Loader, protected routes, RTK base query and refresh
+mutex, duel-session manager, pages/features, browser storage/lifecycle, Duely,
+Taski/Exesh/Analyzer, and user.
+
+## Entry points
+
+Render exception, network/offline error, `401/403/404/409/5xx`, malformed DTO or
+event, timeout/disconnect, lost response, reload/crash, storage failure, stale
+cache/event, duplicate/out-of-order action, and downstream judging delay.
+
+## Preconditions
+
+Failures can occur before or after backend mutation. HTTP status, transport
+failure, parse failure, and domain rejection must be distinguished; current
+paths do this inconsistently.
+
+## Current behavior
+
+Root router/error boundary renders Fallback for selected rendering/routing
+errors. ProtectedRoute redirects only explicit `401`; non-401 `getMe` errors can
+leave Loader indefinitely. Base query tries refresh on `401` and also
+`FETCH_ERROR`, so offline can cause logout; it retries the original request once.
+Many pages show local errors, with special cases such as duel/group `403/404`
+and friendly invitation `409`.
+
+Ticket or WebSocket-constructor failure retries every 3 seconds. An established
+socket `onclose` sets interrupted state but does not schedule reconnect; the
+modal's recovery reloads the page. Socket parse errors warn, unknown messages
+are ignored. RTK manual patches and tag gaps can leave stale data. Storage writes
+fail silently. Submission `.unwrap()` rejection is not locally caught.
+Anti-cheat non-2xx/rejection clears events. Code sync has no ack/retry queue.
+
+## Client state transitions
+
+Errors often retain prior Redux/cache/form state. Refresh failure logs out;
+logout resets auth/session and editor but not RTK or all browser keys. Socket
+close resets searching to idle and sets interruption for authenticated users.
+Reload discards unpersisted state and reconstructs only selected caches.
+
+## Backend state assumptions
+
+The backend can have committed a start/accept/submit even when response is lost.
+Duely and downstream services remain authoritative, but Frontend lacks mutation
+receipts/status queries for several ambiguous outcomes. Status/event delivery is
+not assumed reliable enough to reconstruct every state.
+
+## State ownership
+
+Transport/error UI belongs to the initiating layer. Domain outcome belongs to
+backend. Persisted/client cache cannot decide ambiguous success. There is no
+central error model correlating requests, WebSocket events, storage, and
+downstream execution identifiers.
+
+## UI effects
+
+Effects range from loader, inline/modal error, disabled/stale control, redirect,
+full reload prompt, or no visible feedback. Similar failures receive different
+treatment. Some stale states look successful: ignored group invites, partial
+batch invitations, non-delivered actions, or stale tournament/submission status.
+
+## Network effects
+
+RTK may refresh/replay, refetch matching tags, or keep prior data. Socket ticket
+creation retries; established close does not. No general backoff/circuit breaker
+or offline queue covers mutations. Lifecycle raw fetches bypass refresh logic.
+
+## Idempotency and duplicate handling
+
+Retrying a query is safe; retrying start/accept/create/submit may duplicate
+effects because client idempotency keys are absent. Current code sometimes does
+not retry ambiguous mutations and leaves reconciliation to later queries/events.
+
+## Ordering assumptions
+
+A response can be lost after commit, an event can precede it, and a late HTTP
+snapshot can follow an event. Most workflows lack revisions/generations. Error
+handlers therefore cannot reliably infer whether prior local state is newer.
+
+## Failure handling
+
+Classify recovery as: retry safe reads; refresh once for expired auth; query
+backend status for ambiguous mutation; reconcile critical entities after socket
+loss; preserve unsent user drafts; never clear telemetry as delivered without
+acknowledgement; show actionable and bounded error UI.
+
+Current implementation only satisfies parts of this model and should not be
+described as guaranteeing delivery or exactly-once behavior.
+
+## Reload and multiple tabs
+
+Reload is the primary socket recovery but loses caches/queues and can preserve
+stale workflow/form flags. Another tab may still mutate with old auth/session or
+replace the socket. No shared offline/identity/session coordinator fences it.
+
+## Implementation references
+
+- app providers/router/error components
+- `src/shared/api/api.ts`
+- auth and duel-session APIs/managers
+- storage hooks and persisted slice configurations
+- submit/editor/anti-cheat implementations
+- process-specific documents in this directory
+
+## Test coverage
+
+- **Existing automated tests:** none.
+- **Needed integration:** status/error matrix per endpoint, refresh/replay,
+  malformed contracts, lost response, event reorder, tag recovery, storage faults.
+- **Needed E2E/chaos:** offline/online, socket drop, backend restart, slow/duplicate
+  responses, downstream judging delay, reload/crash, two tabs, user switch.
+
+## Current guarantees
+
+React has a top-level fallback; explicit protected `401` redirects; refresh is
+mutexed per tab and original request is replayed at most once; backend remains
+authorization/domain authority; selected page errors and socket interruption are
+visible.
+
+## Open questions
+
+Global error taxonomy/UX, retry budgets, ambiguous-mutation status endpoints,
+offline support, reconnect SLA, telemetry loss budget, stale-cache tolerance,
+and multi-tab policy are undefined.
+
+## Proposed requirements
+
+Adopt typed/versioned errors and runtime DTO validation; add idempotency/status
+receipts; reconnect with backoff and full reconciliation; make states monotonic;
+atomically reset identity data; observe failures/loss; test fault matrices.
+

--- a/docs/processes/glossary.md
+++ b/docs/processes/glossary.md
@@ -1,0 +1,23 @@
+# Frontend process glossary
+
+| Term | Meaning in current implementation |
+| --- | --- |
+| Auth state | Persisted Redux `user`, access `token`, and `refreshToken`. |
+| `phase` | Persisted duel-session value: exactly `idle`, `searching`, or `active`. |
+| Active duel | Backend `Duel` with `status="InProgress"`; the local `activeDuelId` is only a cached pointer. |
+| RTK Query cache | Process/tab-local normalized-by-endpoint cache. It is not included in redux-persist. |
+| redux-persist | Writes four reducer subtrees to shared-origin localStorage keys `persist:*`. |
+| `lastEventId` | Persisted client field supported by the parser, but current Duely WebSocket messages contain no event ID and reconnect sends none. |
+| Direct invitation | Backend Friendly pending duel. Home queries it with the client argument/type label `Ranked`. |
+| Group invitation | Membership invitation, distinct from a group duel invitation. |
+| Group duel invitation | Pending duel owned by a group with two selected participants. |
+| Tournament duel invitation | Pending duel for a tournament match. |
+| Task key | Duel slot such as `A`; distinct from Taski's 40-hex task ID. |
+| Editor key | `${duelId}:${taskId}`; code is not keyed by user or task key. |
+| Submission ID | Duely integer returned as `id` in detail/create and `submission_id` in list/events. |
+| Terminal submission | Status exactly `Done`; WebSocket manual updates refuse to replace it with a nonterminal status. |
+| Session storage | Per-tab browser storage; cloned in some browser tab-duplication flows but not live-synchronized. |
+| Local storage | Shared by same-origin tabs; Redux instances do not automatically reconcile from later writes. |
+| Conceptual socket state | Documentation labels such as requesting-ticket/connecting; Redux stores only `sessionInterrupted`, not a socket-state enum. |
+| Current guarantee | Behavior established by current code/contracts, not an approved product promise. |
+

--- a/docs/processes/group-duels.md
+++ b/docs/processes/group-duels.md
@@ -1,0 +1,144 @@
+# Group duels
+
+## Purpose
+
+Document manager-created duels between two group members, their invitations,
+acceptance, visibility, and transition into the normal duel session.
+
+## Participants
+
+Group duels section, group managers, two active members, group-duel RTK API,
+Home aggregated invitations, duel-session manager, Duely, and WebSocket.
+
+## Entry points
+
+Open `/groups/:groupId/duels`, create a duel, receive/accept its invitation from
+the group page or Home, open active/finished duel, cancel a pending flow, reload,
+or receive group-duel WebSocket events.
+
+## Preconditions
+
+The creator is authorized by Duely and selects two distinct active members plus
+a permitted configuration. The accepting user still belongs to the group and
+the invitation remains pending.
+
+## Current behavior
+
+The manager form posts the selected pair/configuration and invalidates the
+group-duel list plus invitation data. Pending rows can be accepted; active and
+finished rows link to the duel. Accepting on the group page stores opponent and
+configuration, but not the invitation type or group ID, sets
+`home.waitingForStart=true` in sessionStorage, changes phase to searching, and
+navigates Home. Home has a parallel group-duel acceptance path. Frontend exposes
+no group-duel-specific cancellation mutation even though backend behavior has a
+cancel concept; the generic session cancel is separate.
+
+```mermaid
+sequenceDiagram
+    participant M as Manager
+    participant D as Duely
+    participant U as Group member
+    participant H as Home/session state
+    M->>D: Create group duel(member A, member B, config)
+    D-->>M: Created; invalidate group list
+    D-->>U: GroupDuelInvitation
+    Note over U: Current socket handler does not recognize it
+    U->>D: Accept from fetched list
+    D-->>U: Success
+    U->>H: searching + waitingForStart
+    D-->>U: DuelStarted
+    U->>H: active duel
+```
+
+## Client state transitions
+
+Creation updates only cached lists. Acceptance moves local session to searching;
+`DuelStarted` activates it. The group-page path lacks group/type identity, so a
+cancellation event cannot reliably select this accepted invitation. Finished
+duels remain list entries and open through the common duel route.
+
+## Backend state assumptions
+
+Duely owns group membership, manager permission, invitation status, both
+participants, configuration, and created duel. Client member filtering and
+button visibility cannot prove authorization or freshness.
+
+## State ownership
+
+Group-duel records are backend state cached under a group-specific RTK tag.
+Accepted-waiting projection is split between persisted duelSession and Home
+sessionStorage. Route/component state owns form selection; it is not durable.
+
+## UI effects
+
+Managers see creation controls; members see pending acceptance when returned by
+the query. Active/finished rows are navigable. A pushed invitation is not shown
+immediately unless another invalidation/refetch occurs because current socket
+event names are unhandled.
+
+## Network effects
+
+HTTP loads, creates, and accepts group duels. Mutations invalidate `Duel` group
+and invitation tags. Current Duely emits `GroupDuelInvitation` and
+`GroupDuelInvitationCanceled`; the WebSocket parser accepts arbitrary events but
+has no handlers for either.
+
+## Idempotency and duplicate handling
+
+No client request ID covers create/accept. Duplicate clicks/tabs rely on Duely
+to reject repeated transitions. List invalidation is safe to repeat, while
+duplicate/stale starts are not tied to the group-duel invitation generation.
+
+## Ordering assumptions
+
+Acceptance assumes its HTTP response precedes `DuelStarted`, and navigation to
+Home occurs before the event watcher needs `waitingForStart`. An early event can
+be overwritten by the late `searching` assignment or fail to trigger navigation.
+
+## Failure handling
+
+Mutation errors remain on the form/list. A lost successful accept response can
+leave a created duel without local waiting state. Missed group events leave
+cache stale. Generic cancel may reset local state without proving the group-duel
+invitation was canceled.
+
+## Reload and multiple tabs
+
+Group form state is lost. Persisted opponent/configuration survives; waiting
+flag survives only same-tab sessionStorage. Tabs have separate list caches and
+sockets, so one may accept while another keeps a pending row or sends a repeat.
+
+## Implementation references
+
+- group duel UI/features under `src/pages/group` and `src/entities/group`
+- `src/pages/home/ui/HomePage.tsx`
+- `src/features/duel-session/model/duelSessionSlice.ts`
+- `src/features/duel-session/api/duelSessionApi.ts`
+- Duely group-duel controllers/use cases and WebSocket message enum
+
+## Test coverage
+
+- **Existing tests:** none.
+- **Needed integration:** roles/members, create/accept duplicates, tag coverage,
+  exact group WebSocket types, response/event ordering, cancel semantics.
+- **Needed E2E:** manager plus two member browsers, reload during acceptance,
+  Home versus group-page accept, two groups with same pair/config, two tabs.
+
+## Current guarantees
+
+The current normal HTTP path uses Duely authorization; successful creation
+invalidates the relevant group list; successful acceptance enters the common
+duel waiting flow; active/finished records reuse the standard duel page.
+
+## Open questions
+
+Invitation identity, reject/cancel UI, group ID in events/session state, exact
+manager permissions, expiration, and navigation after acceptance need a single
+contract.
+
+## Proposed requirements
+
+Handle both current backend events; persist an immutable group-duel invitation
+ID/context; make accept/cancel idempotent; reconcile lists on reconnect; and make
+HTTP/event transitions generation-aware.
+

--- a/docs/processes/groups.md
+++ b/docs/processes/groups.md
@@ -1,0 +1,129 @@
+# Groups
+
+## Purpose
+
+Describe group discovery, creation, membership invitations, member/role
+management, leave behavior, and navigation among group sections.
+
+## Participants
+
+Groups page, Group page/layout/redirect, group entity APIs, create/invite/edit
+forms, authenticated user, Creator/Manager/Member roles, Duely, and RTK cache.
+
+## Entry points
+
+`/groups`, `/groups/:groupId`, members/duels/tournaments child routes, create
+group, invite users, accept/deny membership, edit role, remove/leave group, and
+open a shared/deep URL.
+
+## Preconditions
+
+Authentication is required. Route ID must identify a group the backend permits
+the user to inspect. Mutations require backend membership/role authorization;
+client `canManage` and hidden controls are convenience only.
+
+## Current behavior
+
+The groups list supports create and leave. Creation first creates the group,
+then sends selected invitations concurrently with `Promise.allSettled`; failures
+are ignored and the form closes, allowing partial success to look complete.
+Existing-group invitation behaves similarly. `/groups/:id` redirects to
+`members`; the page loads group and users, renders members/duels/tournaments,
+and shows modal/status handling for selected `403/404` errors. Roles are exactly
+`Creator`, `Manager`, `Member`; membership statuses include `Active`, `Pending`.
+Creators can edit non-creators; managers can edit members; self-edit is hidden.
+
+## Client state transitions
+
+Lists/details change through RTK responses and invalidation. Forms and selected
+invitees are component state and disappear on unmount/reload. Successful leave
+navigates to `/groups`. Role/member mutation success refetches tagged group data;
+there is no persisted group workflow slice.
+
+## Backend state assumptions
+
+Duely owns membership, unique roles, invitation state, and permission checks.
+The client assumes its group/user DTO fields and role strings are current.
+Another tab/user can change access at any time, so cached `canManage` is not an
+authorization guarantee.
+
+## State ownership
+
+Group domain state belongs to Duely and is cached in RTK Query. Route owns the
+selected group/section. Component state owns modals/forms. Home sessionStorage
+owns only aggregated invitation presentation, not group membership truth.
+
+## UI effects
+
+Role and status determine action visibility. Group load `403/404` receives
+special feedback; other failures are less specific. Leaving redirects; remote
+removal or role downgrade does not proactively redirect or close already-open
+forms until a request/event/refetch exposes it.
+
+## Network effects
+
+Queries fetch group lists/details/users. Mutations create, invite, accept/deny,
+change role, remove member, and leave. Tag sharing around group ID drives
+refetch. Membership WebSocket events invalidate invitation/list data but do not
+carry a fully authoritative replacement group.
+
+## Idempotency and duplicate handling
+
+No invitation batch transaction or idempotency key spans the create-plus-invite
+sequence. `Promise.allSettled` permits partial completion. Duplicate mutation
+requests rely on backend conflict/transition handling. Cache invalidation is
+repeatable but can refetch multiple active subscriptions.
+
+## Ordering assumptions
+
+Create must finish before invitations. Parallel invites have no client-defined
+order. Role/member changes can race with each other, leave, remote removal, or
+navigation; later responses/refetches determine visible cache state.
+
+## Failure handling
+
+Create failure prevents invites. Individual invite failures after create are
+not summarized or retried by the form. Mutation errors generally keep local
+forms available. Remote access loss surfaces on the next failed request; there
+is no group-specific real-time exclusion handler.
+
+## Reload and multiple tabs
+
+Reload reconstructs group data from HTTP and loses form state. Tabs have
+independent RTK caches and can show different roles/members until invalidation or
+refetch. Logout does not explicitly purge sessionStorage invitation UI keys.
+
+## Implementation references
+
+- `src/pages/groups`
+- `src/pages/group`
+- `src/entities/group`
+- group creation/invitation/member-management features
+- `src/app/router/router.tsx`
+
+## Test coverage
+
+- **Existing tests:** none.
+- **Needed integration:** permissions matrix, tag coverage, partial batch invites,
+  access loss, duplicate mutations, `403/404` and generic failures.
+- **Needed E2E:** create/invite/accept, role changes, leave/removal, deep routes,
+  reload mid-form, concurrent manager tabs, and cross-user changes.
+
+## Current guarantees
+
+Backend endpoints remain the authority; successful create returns a real group
+before invitations begin; normal leave navigates away; direct `/groups/:id`
+lands on members; UI hides known-disallowed actions based on current DTO roles.
+
+## Open questions
+
+Whether invitation batches should be atomic, how partial success is presented,
+how revoked access is pushed, which role changes may race, and whether a group
+selection should persist are not specified.
+
+## Proposed requirements
+
+Return per-invite outcomes and expose retry; model permission failures globally;
+version role/status contracts; invalidate or push access changes consistently;
+and test backend authorization independently of visible UI controls.
+

--- a/docs/processes/open-questions.md
+++ b/docs/processes/open-questions.md
@@ -1,0 +1,51 @@
+# Frontend open questions and risks
+
+The table separates observed behavior from intent. Entries marked confirmed are
+code/contract discrepancies; they are not fixed by this documentation task.
+
+| Area | Observation | Status / question |
+| --- | --- | --- |
+| Event cursor | `lastEventId` is persisted and parsed, but current Duely sends flat messages without it and reconnect never supplies it. | Confirmed unused with current backend; should replay/cursor support exist? |
+| Socket close | Ticket/constructor failures retry after 3000 ms, but normal `onclose` only raises the interrupted modal. | Confirmed; is automatic reconnect intentionally disabled? |
+| Reconnect button | It performs `window.location.reload()`. Closing the modal only clears the flag and leaves the socket closed. | Confirmed; what recovery UX is required? |
+| Socket URL | Client forces `ws:` even when `VITE_BASE_URL` is HTTPS. | Confirmed compatibility risk; production scheme contract needs definition. |
+| Multiple tabs | Duely accepts one socket/user, replaces the old one, then old-connection cleanup can remove the new registry entry and cancel pending duels. | Confirmed cross-layer race; see backend WebSocket docs. |
+| Searching close | Any socket close changes local searching to idle before checking backend; backend disconnect cancels broader pending states. | Confirmed; should backend reconciliation precede UI reset? |
+| Persisted search | Reload explicitly resets searching only for Navigation Timing `reload`; browser reopen/navigation can retain it after backend cleanup. | Confirmed stale-state risk. |
+| Restore thunk | `getActiveDuel.matchFulfilled` calls the thunk creator inside a reducer without dispatch. The manager later dispatches it only when phase is idle. | Confirmed ineffective reducer call; are all phase/ID combinations intentionally covered? |
+| Logout cache | Logout clears auth, session (through manager), editor (extra reducer), and anti-cheat queue through token lifecycle, but does not call `apiSlice.util.resetApiState`. | Confirmed old-user cache risk; which caches must be purged? |
+| Logout browser state | Home/sessionStorage, result dismissal, run panel, and local configuration data are not cleared. | Confirmed cross-user/stale UI risk. |
+| Editor ownership | Logout does clear editor Redux, but same-origin tabs are unsynchronized and can later rewrite shared persisted state. | Confirmed multi-tab caveat; should code be user-scoped? |
+| Refresh trigger | Both 401 and `FETCH_ERROR` attempt refresh; any refresh network/validation failure logs out. | Confirmed offline logout behavior; was `FETCH_ERROR` intentional? |
+| Refresh mutex | Waiters can return the captured old `state.auth.token`; retry headers read current store, but a stale/null return can suppress retry. Mutex is per tab. | Confirmed race surface; should state be re-read after wait? |
+| Token security | Access and refresh tokens live in JavaScript-readable localStorage. | Confirmed XSS exposure; is cookie-based refresh desired? |
+| Runtime validation | Login/user/duel/group/tournament/submission/WebSocket data use TypeScript casts; only refresh tokens and fetched test cases use Superstruct. | Confirmed contract-drift risk. |
+| Early `DuelStarted` | Start/accept handlers set `searching` after HTTP success. An event arriving first sets active, then the late handler regresses phase to searching. | Confirmed ordering race. |
+| Duplicate/old duel event | No event ID/order check exists. An old `DuelStarted` can reactivate a finished duel; an unrelated `DuelFinished` resets the current session. | Confirmed. |
+| Backend event names | Frontend does not handle current `GroupDuelInvitation`, `GroupDuelInvitationCanceled`, or `CodeRunStatusUpdated`; it handles nonexistent current `DuelCanceled` and tournament-canceled aliases. | Confirmed contract mismatch. |
+| Tournament cancel payload | Backend uses generic `DuelInvitationCanceled` without `tournament_id` in accept flow; Tournament matching requires that ID. | Confirmed potential stuck waiting state. |
+| Invitation typing | Direct Friendly invitations are queried/transformed with client type `Ranked`; sender stores `Friendly`, receiver stores `Ranked`. | Confirmed semantic mismatch. |
+| Group matching | Group waiting does not persist group ID/type; cancellation matching uses only opponent/config, so equal invitations across groups can collide. | Confirmed. |
+| Submission-before-cache | Status events update only existing detail/list entries. Unknown submissions are ignored. | Confirmed lost manual update; what should be inserted/refetched? |
+| Submission entries | Submit response updates only the exact filtered list arg; detail updates only unfiltered `{taskKey:null}` list. | Confirmed list/detail/filter divergence risk. |
+| Terminal protection | WebSocket patches protect `Done`, but HTTP merge/detail/refetch can still replace cache data without the same conflict rule. | Confirmed incomplete guarantee. |
+| Reconnect invalidation | On open invalidates `Submission:LIST`/`Tournament:LIST`, but their queries provide `LIST-{duelId}`, entity IDs, or `GROUP-{id}`. Duel/group entity caches are also not broadly covered. | Confirmed stale-cache mismatch and request fan-out risk for tags that do match. |
+| Tournament bracket | Duel finish/invitation messages do not invalidate tournament detail/group tags. | Confirmed stale bracket risk. |
+| Task types | Frontend Task model accepts only `write_code`; Taski also exposes `find_test` and `predict_output`. | Confirmed contract subset; are duel tasks guaranteed WriteCode? |
+| Direct URLs | UI permission/read-only gates do not replace Duely authorization; invalid duel ID can still lead child widgets to query `/duels/NaN`. | Confirmed. |
+| Active navigation | Socket manager changes Redux globally but only Home/session-button effects navigate. An event on another route can leave an active duel without navigation. | Confirmed. |
+| Duel finish ordering | Listener resets the session before invalidation effects/refetch complete. | Confirmed; could UI/header lose needed context? |
+| Editor conflict | Every successful duel fetch applies backend solutions over persisted local drafts; a pending 500 ms local debounce can then overwrite Redux again. | Confirmed race; define conflict winner. |
+| Code sync scope | Interval checks privacy flag but not participant, duel status, or `phase`; spectators/finished pages can attempt sends that backend must reject. | Confirmed defense-in-depth gap. |
+| Code sync delivery | Only selected task, full code, at most once per second/change; last edit can be lost at close and two tabs can send divergent versions. | Confirmed best-effort behavior. |
+| Home persistence | Forms/modals/nickname/config/waiting/pending action IDs are per-tab, unversioned, not user-scoped. Reload mid-deny can leave a permanently disabled item. | Confirmed. |
+| Run panel | Persisted `running` state contains no run ID, so reload cannot resume polling and can display stale running forever. | Confirmed. |
+| Configuration local cache | `duel-configurations` duplicates backend configuration data, is unversioned/user-independent, and is not initialized from the server. | Confirmed stale/cross-user risk. |
+| Sequential task snapshot | Snapshots/opened keys are memory-only. Reload establishes a new baseline and shows no newly-opened notification. | Confirmed; is that acceptable? |
+| Anti-cheat delivery | Queue is memory-only; `finally` clears all events even on fetch rejection/non-2xx/`shouldSend=false`; no `sendBeacon`, ack, or retry. | Confirmed loss semantics. |
+| Anti-cheat concurrency | Events added during a flush can be cleared with the sent queue; sequence counters reset after every flush and per tab. | Confirmed ordering/loss risk. |
+| Spectator tracking | Auto-flush requires participant, but editor trackers are enabled only after participant check; code-sync interval itself is not participant-gated. | Mixed controls; require browser/backend E2E validation. |
+| Corrupt/old persistence | Persist configs are version 1 but no migrations are supplied; custom storage hooks silently fall back on parse failure and then overwrite. | Confirmed; define migration/quarantine policy. |
+| Protected network error | With a token, non-401 `getMe` failure displays Loader indefinitely; original URL is not saved across auth redirect. | Confirmed UX/recovery gap. |
+| Group bulk invites | `Promise.allSettled` results are ignored, so forms close on partial or total invite failure. | Confirmed false-success UI risk. |
+

--- a/docs/processes/open-questions.md
+++ b/docs/processes/open-questions.md
@@ -1,51 +1,64 @@
 # Frontend open questions and risks
 
-The table separates observed behavior from intent. Entries marked confirmed are
-code/contract discrepancies; they are not fixed by this documentation task.
+The table separates evidence from impact and intent. Classifications mean:
 
-| Area | Observation | Status / question |
-| --- | --- | --- |
-| Event cursor | `lastEventId` is persisted and parsed, but current Duely sends flat messages without it and reconnect never supplies it. | Confirmed unused with current backend; should replay/cursor support exist? |
-| Socket close | Ticket/constructor failures retry after 3000 ms, but normal `onclose` only raises the interrupted modal. | Confirmed; is automatic reconnect intentionally disabled? |
-| Reconnect button | It performs `window.location.reload()`. Closing the modal only clears the flag and leaves the socket closed. | Confirmed; what recovery UX is required? |
-| Socket URL | Client forces `ws:` even when `VITE_BASE_URL` is HTTPS. | Confirmed compatibility risk; production scheme contract needs definition. |
-| Multiple tabs | Duely accepts one socket/user, replaces the old one, then old-connection cleanup can remove the new registry entry and cancel pending duels. | Confirmed cross-layer race; see backend WebSocket docs. |
-| Searching close | Any socket close changes local searching to idle before checking backend; backend disconnect cancels broader pending states. | Confirmed; should backend reconciliation precede UI reset? |
-| Persisted search | Reload explicitly resets searching only for Navigation Timing `reload`; browser reopen/navigation can retain it after backend cleanup. | Confirmed stale-state risk. |
-| Restore thunk | `getActiveDuel.matchFulfilled` calls the thunk creator inside a reducer without dispatch. The manager later dispatches it only when phase is idle. | Confirmed ineffective reducer call; are all phase/ID combinations intentionally covered? |
-| Logout cache | Logout clears auth, session (through manager), editor (extra reducer), and anti-cheat queue through token lifecycle, but does not call `apiSlice.util.resetApiState`. | Confirmed old-user cache risk; which caches must be purged? |
-| Logout browser state | Home/sessionStorage, result dismissal, run panel, and local configuration data are not cleared. | Confirmed cross-user/stale UI risk. |
-| Editor ownership | Logout does clear editor Redux, but same-origin tabs are unsynchronized and can later rewrite shared persisted state. | Confirmed multi-tab caveat; should code be user-scoped? |
-| Refresh trigger | Both 401 and `FETCH_ERROR` attempt refresh; any refresh network/validation failure logs out. | Confirmed offline logout behavior; was `FETCH_ERROR` intentional? |
-| Refresh mutex | Waiters can return the captured old `state.auth.token`; retry headers read current store, but a stale/null return can suppress retry. Mutex is per tab. | Confirmed race surface; should state be re-read after wait? |
-| Token security | Access and refresh tokens live in JavaScript-readable localStorage. | Confirmed XSS exposure; is cookie-based refresh desired? |
-| Runtime validation | Login/user/duel/group/tournament/submission/WebSocket data use TypeScript casts; only refresh tokens and fetched test cases use Superstruct. | Confirmed contract-drift risk. |
-| Early `DuelStarted` | Start/accept handlers set `searching` after HTTP success. An event arriving first sets active, then the late handler regresses phase to searching. | Confirmed ordering race. |
-| Duplicate/old duel event | No event ID/order check exists. An old `DuelStarted` can reactivate a finished duel; an unrelated `DuelFinished` resets the current session. | Confirmed. |
-| Backend event names | Frontend does not handle current `GroupDuelInvitation`, `GroupDuelInvitationCanceled`, or `CodeRunStatusUpdated`; it handles nonexistent current `DuelCanceled` and tournament-canceled aliases. | Confirmed contract mismatch. |
-| Tournament cancel payload | Backend uses generic `DuelInvitationCanceled` without `tournament_id` in accept flow; Tournament matching requires that ID. | Confirmed potential stuck waiting state. |
-| Invitation typing | Direct Friendly invitations are queried/transformed with client type `Ranked`; sender stores `Friendly`, receiver stores `Ranked`. | Confirmed semantic mismatch. |
-| Group matching | Group waiting does not persist group ID/type; cancellation matching uses only opponent/config, so equal invitations across groups can collide. | Confirmed. |
-| Submission-before-cache | Status events update only existing detail/list entries. Unknown submissions are ignored. | Confirmed lost manual update; what should be inserted/refetched? |
-| Submission entries | Submit response updates only the exact filtered list arg; detail updates only unfiltered `{taskKey:null}` list. | Confirmed list/detail/filter divergence risk. |
-| Terminal protection | WebSocket patches protect `Done`, but HTTP merge/detail/refetch can still replace cache data without the same conflict rule. | Confirmed incomplete guarantee. |
-| Reconnect invalidation | On open invalidates `Submission:LIST`/`Tournament:LIST`, but their queries provide `LIST-{duelId}`, entity IDs, or `GROUP-{id}`. Duel/group entity caches are also not broadly covered. | Confirmed stale-cache mismatch and request fan-out risk for tags that do match. |
-| Tournament bracket | Duel finish/invitation messages do not invalidate tournament detail/group tags. | Confirmed stale bracket risk. |
-| Task types | Frontend Task model accepts only `write_code`; Taski also exposes `find_test` and `predict_output`. | Confirmed contract subset; are duel tasks guaranteed WriteCode? |
-| Direct URLs | UI permission/read-only gates do not replace Duely authorization; invalid duel ID can still lead child widgets to query `/duels/NaN`. | Confirmed. |
-| Active navigation | Socket manager changes Redux globally but only Home/session-button effects navigate. An event on another route can leave an active duel without navigation. | Confirmed. |
-| Duel finish ordering | Listener resets the session before invalidation effects/refetch complete. | Confirmed; could UI/header lose needed context? |
-| Editor conflict | Every successful duel fetch applies backend solutions over persisted local drafts; a pending 500 ms local debounce can then overwrite Redux again. | Confirmed race; define conflict winner. |
-| Code sync scope | Interval checks privacy flag but not participant, duel status, or `phase`; spectators/finished pages can attempt sends that backend must reject. | Confirmed defense-in-depth gap. |
-| Code sync delivery | Only selected task, full code, at most once per second/change; last edit can be lost at close and two tabs can send divergent versions. | Confirmed best-effort behavior. |
-| Home persistence | Forms/modals/nickname/config/waiting/pending action IDs are per-tab, unversioned, not user-scoped. Reload mid-deny can leave a permanently disabled item. | Confirmed. |
-| Run panel | Persisted `running` state contains no run ID, so reload cannot resume polling and can display stale running forever. | Confirmed. |
-| Configuration local cache | `duel-configurations` duplicates backend configuration data, is unversioned/user-independent, and is not initialized from the server. | Confirmed stale/cross-user risk. |
-| Sequential task snapshot | Snapshots/opened keys are memory-only. Reload establishes a new baseline and shows no newly-opened notification. | Confirmed; is that acceptable? |
-| Anti-cheat delivery | Queue is memory-only; `finally` clears all events even on fetch rejection/non-2xx/`shouldSend=false`; no `sendBeacon`, ack, or retry. | Confirmed loss semantics. |
-| Anti-cheat concurrency | Events added during a flush can be cleared with the sent queue; sequence counters reset after every flush and per tab. | Confirmed ordering/loss risk. |
-| Spectator tracking | Auto-flush requires participant, but editor trackers are enabled only after participant check; code-sync interval itself is not participant-gated. | Mixed controls; require browser/backend E2E validation. |
-| Corrupt/old persistence | Persist configs are version 1 but no migrations are supplied; custom storage hooks silently fall back on parse failure and then overwrite. | Confirmed; define migration/quarantine policy. |
-| Protected network error | With a token, non-401 `getMe` failure displays Loader indefinitely; original URL is not saved across auth redirect. | Confirmed UX/recovery gap. |
-| Group bulk invites | `Promise.allSettled` results are ignored, so forms close on partial or total invite failure. | Confirmed false-success UI risk. |
+- **Confirmed behavior:** directly observed in current code without asserting
+  that it is correct or incorrect.
+- **Confirmed defect:** current code cannot reliably achieve the operation it
+  already attempts to perform.
+- **Confirmed contract mismatch:** current producer and consumer contracts
+  demonstrably disagree.
+- **Potential risk:** the consequence depends on timing, environment, data, or
+  user behavior and is not asserted as an observed production failure.
+- **Product decision required:** current behavior is known, but the desired
+  product rule is not defined.
 
+| Area | Confirmed observation | Classification | Remaining question or possible impact |
+| --- | --- | --- | --- |
+| Event cursor | `lastEventId` is persisted and parsed, but current Duely sends flat messages without it and reconnect never supplies it. | Confirmed contract mismatch | Should replay/cursor support exist, or should the unused client state be removed? |
+| Socket close | Ticket/constructor failures retry after 3000 ms, but established-socket `onclose` only raises the interrupted modal. | Confirmed behavior | Is automatic reconnect intentionally disabled? |
+| Reconnect button | It performs `window.location.reload()`; clearing the modal flag alone leaves the socket closed. | Confirmed behavior | What recovery UX is required? |
+| Socket URL | Client forces `ws:` even when `VITE_BASE_URL` is HTTPS. | Potential risk | An HTTPS deployment may reject mixed content; the production scheme contract needs definition. |
+| Multiple tabs | Duely keeps one process-local socket/user; old-handler cleanup is not generation-aware. | Potential risk | An old handler can remove a newer registration or cancel newer pending state if the timing overlaps. |
+| Backend close cleanup | The ordinary `finally` path attempts close, map removal, and `CancelPendingDuels`, but current-socket `CloseAsync` is not caught. | Potential risk | A close exception or process termination can prevent later cleanup; cleanup is not guaranteed for every termination. |
+| Searching close | Any frontend socket close changes local searching to idle before backend reconciliation. | Product decision required | Should backend status be checked before the UI transition? |
+| Persisted search | Reload explicitly resets searching only for Navigation Timing `reload`; browser reopen/navigation can retain it. | Potential risk | Persisted state can outlive backend pending-state cleanup. |
+| Restore thunk | `getActiveDuel.matchFulfilled` calls a thunk creator inside a reducer without dispatching the thunk. | Confirmed defect | The manager covers only `phase=idle`; other persisted phase/ID combinations remain unreconciled. |
+| Logout cache | Logout does not call `apiSlice.util.resetApiState`. | Potential risk | Old-user cache can remain until teardown/eviction and should have an explicit purge policy. |
+| Logout browser state | Home/sessionStorage, result dismissal, run panel, and local configuration keys are not cleared. | Potential risk | These unscoped values can appear for a later user in the same browser/tab. |
+| Editor ownership | Logout clears editor Redux, but tabs are unsynchronized and can later rewrite shared persisted state. | Potential risk | Should drafts be user-scoped and stale writers fenced? |
+| Refresh trigger | Both `401` and `FETCH_ERROR` attempt refresh; refresh network/validation failure dispatches logout. | Confirmed behavior | Was offline logout intended? |
+| Refresh mutex | Waiters return the token from a captured pre-wait state; the mutex is per tab. | Potential risk | A stale/null return can suppress replay even though retry headers otherwise read current Redux. |
+| Token storage | Access and refresh tokens are stored in JavaScript-readable localStorage. | Potential risk | Define the accepted XSS threat model and whether cookie-based refresh is required. |
+| Runtime validation | Most HTTP/WebSocket DTOs use TypeScript casts; refresh tokens and fetched test cases use Superstruct. | Potential risk | Contract drift can become silent state corruption; define required runtime-validation coverage. |
+| Early `DuelStarted` | An event can set `active`, then a later successful start/accept handler writes `searching`. | Confirmed defect | Transitions need a request/session generation or order-independent reducer rule. |
+| Duplicate/old duel event | Duel events have no client event ID or generation check. | Potential risk | A delayed start/finish can affect a later session if delivery is reordered or duplicated. |
+| Backend event names | Frontend ignores current `GroupDuelInvitation`, `GroupDuelInvitationCanceled`, and `CodeRunStatusUpdated`, while handling event aliases not emitted by current Duely. | Confirmed contract mismatch | Align the exhaustive event registry and compatibility policy. |
+| Tournament cancel payload | Current generic `DuelInvitationCanceled` can omit `tournament_id`, while frontend tournament matching requires it. | Confirmed contract mismatch | Define an immutable invitation/tournament identity in every cancellation. |
+| Invitation typing | Direct Friendly invitations are queried/transformed as client type `Ranked`; sender and receiver persist different type labels. | Confirmed contract mismatch | Align domain vocabulary and migration/compatibility behavior. |
+| Group matching | Waiting state does not retain group ID/type and matches opponent/configuration only. | Potential risk | Equal invitations across groups can collide if they overlap. |
+| Submission-before-cache | Status events update only existing detail/list entries; unknown submissions are ignored. | Confirmed behavior | Should the event upsert or invalidate a matching list? |
+| Submission entries | Create updates only the exact filtered list arg; detail updates only the unfiltered `{taskKey:null}` list. | Confirmed behavior | Define normalization/reconciliation across all filters. |
+| Terminal protection | WebSocket patches protect `Done`; normal HTTP merge/detail/refetch does not apply the same rule. | Potential risk | A late HTTP snapshot can regress displayed terminal state without a revision. |
+| Reconnect invalidation | Socket open invalidates `Submission:LIST` and `Tournament:LIST`, but queries provide different IDs. | Confirmed defect | The intended reconnect reconciliation does not target those cache entries. |
+| Tournament bracket | Duel finish/invitation events do not invalidate tournament entity/group tags. | Potential risk | An already-cached bracket can remain stale until another refetch trigger. |
+| Task types | Frontend models only `write_code`; Taski also defines `find_test` and `predict_output`. | Product decision required | Are duel tasks contractually restricted to `write_code`? |
+| UI permissions | Read-only/hidden controls do not replace Duely authorization. | Confirmed behavior | Backend authorization must remain the security boundary. |
+| Invalid duel URL | Child widgets can issue `/duels/NaN` after an invalid route parameter. | Confirmed defect | Validate the route once before rendering/querying children. |
+| Active navigation | Socket manager updates Redux globally, but only Home/session-button effects navigate. | Product decision required | Should every `DuelStarted` force navigation from every route? |
+| Duel finish ordering | Listener resets the session before invalidation/refetch completes. | Product decision required | Define which context must remain visible until result data is loaded. |
+| Editor conflict | Duel hydration and a pending local debounce both write the same persisted draft without revisions. | Potential risk | Define the conflict winner and acknowledgement model. |
+| Code sync scope | Interval gates on privacy/socket state, not participant, duel status, or local phase; Duely performs final authorization. | Confirmed behavior | Is stricter client gating required for traffic/UX, without treating it as security? |
+| Code sync delivery | Only the selected task is sent, at most once per second/change, without acknowledgement or final flush. | Confirmed behavior | Define acceptable loss/conflict behavior at close and across tabs. |
+| Home persistence | Forms, selected configuration, waiting state, and pending IDs are per-tab, unversioned, and not user-scoped. | Potential risk | Reload or user switch can retain stale/disabled UI. |
+| Run panel | Persisted `running` state has no run ID, so reload cannot resume its polling. | Confirmed defect | A reloaded panel can remain in an unrecoverable local running state. |
+| Configuration local cache | `duel-configurations` duplicates backend data and is unversioned/user-independent. | Potential risk | Define whether it is a draft cache, a durable source, or should be removed. |
+| Sequential task snapshot | Open-task snapshots are memory-only and reload establishes a new baseline without a notification. | Product decision required | Is suppressing historical open-task notifications after reload intended? |
+| Anti-cheat delivery | Queue is memory-only and `finally` clears it after rejection, non-2xx resolution, or `shouldSend=false`; there is no ack/retry. | Confirmed behavior | Define acceptable loss rate and delivery/retention requirements. |
+| Anti-cheat concurrency | Events added during a flush share mutable queue cleanup; sequence counters reset after every flush and per tab. | Potential risk | Events can be lost or streams can have ambiguous order under overlap. |
+| Anti-cheat backend validation | Duely checks payload `UserId` against the authenticated user and filters missing/finished duels, but does not verify duel participation or task existence. | Confirmed behavior | Should participation and task membership be required at ingestion? |
+| Anti-cheat duplicates | `EventId` has no unique constraint and the save handler does not look it up. | Confirmed behavior | Reposting a batch can create duplicates; decide whether `EventId` is an idempotency key. |
+| Spectator tracking | Editor tracking is participant-gated, while code-sync interval itself is not participant-gated. | Product decision required | Validate desired browser behavior separately from backend authorization. |
+| Corrupt/old persistence | Persist configs are version 1 without migrations; custom hooks fall back on parse failure and later overwrite. | Potential risk | Define migration, quarantine, and recovery policy. |
+| Protected network error | With a token, non-401 `getMe` failure leaves Loader; auth redirect does not preserve the original URL. | Confirmed behavior | Define bounded error/offline and return-navigation UX. |
+| Group bulk invites | `Promise.allSettled` results are ignored and forms close after the batch settles. | Confirmed behavior | Define how partial/total invite failure should be reported and retried. |

--- a/docs/processes/ranked-matchmaking.md
+++ b/docs/processes/ranked-matchmaking.md
@@ -1,0 +1,149 @@
+# Ranked matchmaking
+
+## Purpose
+
+Describe how a user starts and cancels rating-based matchmaking and how the
+client turns a backend-created duel into an active browser session.
+
+## Participants
+
+Home quick-search controls, `DuelSessionButton`, duel-session Redux slice and
+manager, RTK Query duel API, authenticated WebSocket, Duely, and browser tabs.
+
+## Entry points
+
+The Home quick-search action, the header/session button, cancel controls, a
+`DuelStarted` event, reconnect/reload, and logout.
+
+## Preconditions
+
+The user has an access token and chooses a usable duel configuration. Duely,
+not the client, decides eligibility, rating pairing, and whether a pending
+search can be created or canceled.
+
+## Current behavior
+
+Both start controls clear persisted invitation matching fields, call
+`POST /duels/search`, and set `phase=searching` only after a successful response.
+Cancel calls `POST /duels/cancel` and then moves to `idle`. A `DuelStarted`
+message stores the duel ID and activates the session. Navigation is conditional:
+the session button watches its own transition, while Home navigates only when
+its local/session `waitingForStart` flag is set. Search actions are not globally
+serialized and a rapid double click can issue duplicate requests.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant UI as Home/session button
+    participant D as Duely HTTP
+    participant W as WebSocket
+    participant S as duelSession
+    U->>UI: Start ranked search
+    UI->>D: POST /duels/search
+    D-->>UI: Success
+    UI->>S: phase = searching
+    D-->>W: DuelStarted(duel_id)
+    W->>S: activeDuelId + phase = active
+    UI->>UI: Navigate only if local watcher applies
+    alt Cancel before pairing
+        U->>UI: Cancel
+        UI->>D: POST /duels/cancel
+        D-->>UI: Success
+        UI->>S: phase = idle
+    end
+```
+
+## Client state transitions
+
+Nominally `idle -> searching -> active -> idle`. Start clears opponent,
+configuration, invitation type, and tournament matching values. An early
+`DuelStarted` can set `active` before the start response; the late success
+handler then writes `searching` while retaining `activeDuelId`, producing an
+inconsistent persisted state. Socket close converts `searching` to `idle`.
+
+## Backend state assumptions
+
+The backend owns the queue, pairing, pending-duel cleanup, and created duel.
+Client `phase` is only a projection. Starting ranked search may also invalidate
+other pending friendly state on the backend even though the UI does not refresh
+all invitation data immediately.
+
+## State ownership
+
+Duely owns whether the user is searching and the resulting active duel.
+Persisted duel-session fields own UI continuity only. Component mutation flags
+own temporary spinners; RTK cache owns received duel/configuration snapshots.
+
+## UI effects
+
+Searching shows a cancel state. Active state may expose a session button or
+trigger navigation from the control that initiated the flow. A start event on
+an unrelated page does not guarantee global navigation. Rejected mutations
+leave the previous local phase and surface endpoint-specific errors.
+
+## Network effects
+
+Start and cancel are authenticated HTTP mutations. Pairing completion arrives
+by WebSocket. Cancel invalidates invitation/group-related tags, but the generic
+`Tournament/LIST` key does not match the tournament tags actually provided.
+
+## Idempotency and duplicate handling
+
+No client idempotency key is sent. Mutation loading state narrows but does not
+eliminate rapid duplicate requests. Repeated `DuelStarted` assignments are
+mostly reducer-idempotent, but an old event can reactivate the wrong duel.
+
+## Ordering assumptions
+
+The implementation assumes the start response precedes `DuelStarted` and the
+cancel response precedes any pairing event. Neither order is encoded in an
+event ID, search generation, or compare-and-set transition.
+
+## Failure handling
+
+A lost successful start response leaves the backend searching while the client
+stays idle. A lost successful cancel response leaves the client searching. On
+socket close, local search is reset; backend disconnect handling is expected to
+cancel pending work. There is no status endpoint dedicated to reconciliation.
+
+## Reload and multiple tabs
+
+Reload preserves `searching`, but the manager resets a searching session with
+no active duel to idle on reload/navigation without first verifying/canceling
+backend state. Each tab can start/cancel independently and receives a competing
+socket lifecycle; no tab owns the search generation.
+
+## Implementation references
+
+- `src/pages/home/ui/HomePage.tsx`
+- `src/features/duel-session/ui/DuelSessionButton.tsx`
+- `src/features/duel-session/model/duelSessionSlice.ts`
+- `src/features/duel-session/api/duelSessionApi.ts`
+- `src/entities/duel/api/duelApi.ts`
+
+## Test coverage
+
+- **Existing tests:** none.
+- **Needed integration:** response/event in both orders, response loss, duplicate
+  start/cancel, stale start event, rejected eligibility, tag invalidation.
+- **Needed E2E:** start/cancel from both controls, reload while searching,
+  navigate away before pairing, disconnect, and two-tab races.
+
+## Current guarantees
+
+The client does not mark search active before the HTTP start succeeds; a normal
+current `DuelStarted` stores its ID; a successful cancel returns local phase to
+idle; logout resets the duel-session slice.
+
+## Open questions
+
+The canonical pending-search status, global navigation policy, idempotency key,
+event generation, and precedence between ranked and invitation flows are not
+defined in the client contract.
+
+## Proposed requirements
+
+Expose a backend session/search identifier and status query; make transitions
+generation-aware and order-independent; disable/serialize duplicate actions;
+reconcile after reload/reconnect; and define one global navigation policy.
+

--- a/docs/processes/realtime-connection.md
+++ b/docs/processes/realtime-connection.md
@@ -1,0 +1,201 @@
+# Realtime connection and WebSocket events
+
+## Purpose
+
+Maintain the authenticated user socket for one tab, translate Duely messages
+into Redux/cache/UI effects, and send best-effort opponent-code updates.
+
+## Participants
+
+DuelSessionManager, duel-session RTK cache entry, auth/user ticket endpoint,
+browser WebSocket/timers, duel-session/editor Redux, RTK caches, Home/duel UI,
+Duely connection manager/outbox, and multiple tabs.
+
+## Entry points
+
+Auth user becomes non-null, subscription cache entry is added/removed, ticket
+or socket fails, socket opens/messages/closes, logout, reload, reconnect button,
+or second tab connects.
+
+## Preconditions
+
+Auth Redux has token and current user. `VITE_BASE_URL` forms a valid URL, Duely
+can issue a one-use ticket, and browser permits the constructed `ws:` URL.
+
+## Current behavior
+
+The single normally-mounted manager dispatches one `subscribeToDuelStates`
+query subscription. Its cache lifecycle obtains `POST /users/ticket`, constructs
+`{basePath}/users/connect?ticket=...` while forcing protocol `ws:`, closes any
+local prior socket, then constructs WebSocket. Tickets are random, stored on the
+user, overwritten by a new ticket, and consumed once; no expiry timestamp exists.
+
+Ticket request or constructor failure schedules another full ticket/connect in
+3000 ms after clearing the previous timer. `onopen` clears that timer and
+`sessionInterrupted`, then invalidates selected broad tags. `onerror` only logs.
+`onclose` resets local searching to idle, and if a token still exists sets the
+interrupted modal; it does not schedule reconnect or null the socket. The modal
+cannot be normally dismissed and its button reloads the page; its `onClose`
+handler would only clear the flag. Logout unsubscribes; cache removal clears
+interval/timer and closes the socket. The manager effect itself has no unmount
+cleanup, a risk for abnormal remounts.
+
+The parser accepts flat backend objects or envelopes with `event|type|name`,
+`data|payload`, camel/snake last-event ID, and stringified payload. Event names
+remove nonletters and lowercase. Payloads are TypeScript-cast, not runtime-
+validated. Current Duely sends flat polymorphic JSON with `type` and fields; it
+does not send `lastEventId`, so the persisted field remains unused and no replay
+cursor is sent on reconnect.
+
+| Event name | Current backend payload | Redux mutation | Cache mutation | Navigation/UI effect |
+| --- | --- | --- | --- | --- |
+| `DuelStarted` | `duel_id` | active ID; phase becomes active; clear search | invalidate Duel ID | Navigation only in Home/session-button effects |
+| `DuelFinished` | `duel_id` | reset whole session | Duel ID + User ME | duel result comes from refetch; can reset unrelated active duel |
+| `DuelCanceled` | opponent optional | reset; canceled modal | None | Client handles it, current backend has no such type |
+| `DuelChanged` or nameless object with `duel_id` | current backend only `duel_id` | last ID only; full noncurrent envelope could overwrite code | invalidate Duel ID | task/result changes after refetch |
+| `DuelInvitation` | opponent/config | None | DuelInvitation LIST | invitation list refetch |
+| `DuelInvitationCanceled` | opponent/config | maybe phase idle if match | DuelInvitation LIST | waiting/search can stop |
+| `DuelInvitationDenied` | opponent/config | matching search -> idle + canceled dialog | DuelInvitation LIST | denial modal |
+| `TournamentDuelInvitation` (alias accepted) | tournament/opponent/config | None | DuelInvitation LIST | incoming list refetch |
+| tournament-canceled aliases | no current backend message | maybe phase idle when tournament ID matches | DuelInvitation LIST | dead compatibility path currently |
+| `GroupInvitation` | group/role/inviter | None | GroupInvitation LIST | membership invitation refetch |
+| `GroupInvitationCanceled` | group fields | None | GroupInvitation LIST | removal refetch |
+| `GroupDuelInvitation` / canceled | backend emits both | None | None | Unknown and silently ignored: confirmed mismatch |
+| `OpponentSolutionUpdated` | duel/task/language/solution | opponent editor maps when cached privacy flag true | None | opponent tab changes |
+| `SubmissionStatusUpdated` | duel/submission/status/message/verdict | None | patch existing detail/all cached duel lists; protect `Done` | rows/detail update if present |
+| `CodeRunStatusUpdated` | run/status/error | None | None | Unhandled; run UI uses HTTP polling |
+| Unknown/malformed | arbitrary | only last ID may be stored before unknown dispatch; malformed ignored | None | console warning only for parse failure |
+
+```mermaid
+stateDiagram-v2
+    [*] --> disconnected
+    disconnected --> requesting_ticket: subscription with token
+    requesting_ticket --> connecting: ticket returned
+    requesting_ticket --> requesting_ticket: 3s retry
+    connecting --> connected: onopen
+    connecting --> requesting_ticket: constructor failure / 3s retry
+    connected --> interrupted: onclose with token
+    interrupted --> disconnected: logout/cache removal
+    interrupted --> requesting_ticket: full page reload (new runtime)
+```
+
+Labels except `sessionInterrupted` are conceptual; no socket-state enum exists.
+
+```mermaid
+sequenceDiagram
+    participant A as Tab A
+    participant B as Duely connection registry
+    participant T as Tab B
+    A->>B: connect as user
+    T->>B: connect same user
+    B->>A: close "Replaced by new connection"
+    B->>B: register Tab B socket
+    A->>B: old finally removes user entry and cancels pending duels
+    A-->>A: phase searching -> idle; interrupted modal
+    Note over B,T: Tab B socket may stay open but no longer be registry target
+```
+
+## Client state transitions
+
+`sessionInterrupted: false -> true on close -> false on open/modal handler`;
+`phase: searching -> idle on any close`; socket conceptual flow is above.
+Messages set `idle/searching/active` without event-order checks. `lastEventId`
+changes only if a noncurrent envelope supplies it.
+
+## Backend state assumptions
+
+Duely is authoritative and allows one registered socket/user. Disconnect always
+runs `CancelPendingDuels`; replacing a socket therefore affects matchmaking.
+Frontend assumes ticket response/string, flat event fields/enums, and server
+authorization of `SolutionUpdated`. No replay endpoint reconciles missed events.
+
+## State ownership
+
+| State | Owner/source of truth | Redux | RTK Query | local state | sessionStorage | localStorage | Survives reload |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Socket/timers/last sent code | tab subscription | No | cache lifecycle | closure | No | No | No |
+| Interrupted flag/phase/active ID | client from backend | duelSession | No | manager reconnect flag | No | phase/ID persisted | Partial |
+| Event cursor | no current producer | duelSession | No | No | No | persisted field | Yes but unused |
+| Domain data | Duely | partial workflow | endpoint caches | No | No | No | No |
+| Opponent code | Duely messages/details | codeEditor | Duel supplies initial | Monaco mirror | code tab only | not whitelisted | No |
+
+## UI effects
+
+Close shows a blocking no-close-button modal; reload button displays local
+"reconnecting" until page unload. Searching loader disappears immediately on
+close. Events invalidate lists/details or mutate code/submissions, but socket
+manager itself does not navigate; only mounted workflow components do.
+
+## Network effects
+
+Ticket and connection retries are infinite only before a socket object opens.
+On open, invalidations that actually match can trigger concurrent requests.
+Socket receives flat messages and sends full selected-task solution/language at
+most once per second when changed and cached privacy flag is true. No ack exists.
+
+## Idempotency and duplicate handling
+
+No event-ID/order dedupe exists. Repeated invitation events repeat invalidation;
+submission patches protect terminal `Done` but unknown entries are ignored;
+duplicate/old duel starts/finishes repeat workflow resets. Code send suppresses
+only equality against one in-memory last-selected payload.
+
+## Ordering assumptions
+
+Start/finish/change events are assumed chronological and relevant to current
+session. HTTP start completion is assumed before `DuelStarted`, which is not
+guaranteed. Connection replacement/cleanup has no generation token. Payload
+casts assume backend names/fields remain compatible.
+
+## Failure handling
+
+Ticket/constructor failures log and retry. Socket error alone logs; close needs
+manual reload. Malformed JSON/string payload is ignored. Unknown events are
+silent. Missed events rely on later HTTP refetch, but reconnect invalidation does
+not cover all real tags. Mixed-content `ws:` may prevent connection under HTTPS.
+
+## Reload and multiple tabs
+
+Reload destroys/recreates socket with a new ticket and empty cache. Each tab
+opens its own socket and has independent timers/cache/sessionStorage but shared
+persisted Redux bytes. Backend replacement interrupts the old tab and cleanup
+can cancel search/remove the new registry entry. Tabs have no leader election.
+
+## Implementation references
+
+- `src/features/duel-session/api/duelSessionApi.ts`
+- `src/features/duel-session/ui/DuelSessionManager/DuelSessionManager.tsx`
+- `src/features/duel-session/lib/const.ts`
+- Backend `UserWebSocketHandler`, `WebSocketMessageSender`, message types
+- Backend docs: `../../../Backend/docs/processes/user-connection-lifecycle.md`
+
+## Test coverage
+
+- **Existing tests/MSW:** none.
+- **Needed unit/integration:** URL/scheme, ticket retries, lifecycle cleanup,
+  every event/flat-envelope/string payload, malformed/unknown/duplicate/order,
+  tag/manual patches, code send gating.
+- **Needed browser/E2E:** real socket open/close/reload, expired ticket, offline,
+  early event, missed event/refetch, two tabs/replacement/search cleanup, HTTPS,
+  logout/remount, and privacy/spectator flows.
+
+## Current guarantees
+
+Normal app tree has one subscription per tab; pre-open failures retry at 3000
+ms; open clears the scheduled timer; cache removal clears owned timers/socket;
+current flat backend event names listed as handled produce the documented
+mutations; code sync checks cached privacy flag and open readyState.
+
+## Open questions
+
+Automatic reconnect/replay, scheme selection, event validation/versioning,
+multi-tab connection ownership, disconnect cleanup semantics, and complete
+cache reconciliation are unresolved.
+
+## Proposed requirements
+
+Use secure scheme derived from base URL; model socket state/generation; reconnect
+with backoff and replay cursor or full reconciliation; runtime-validate/version
+events; handle all backend message types; guarantee cleanup on unmount; elect a
+cross-tab owner or support multi-connection backend; and E2E-test replacement.
+

--- a/docs/processes/realtime-connection.md
+++ b/docs/processes/realtime-connection.md
@@ -20,7 +20,9 @@ or second tab connects.
 ## Preconditions
 
 Auth Redux has token and current user. `VITE_BASE_URL` forms a valid URL, Duely
-can issue a one-use ticket, and browser permits the constructed `ws:` URL.
+can issue an intended single-use ticket, and browser permits the constructed
+`ws:` URL. Backend ticket lookup and clearing are separate read/write steps and
+are not an atomic consume operation.
 
 ## Current behavior
 
@@ -28,7 +30,9 @@ The single normally-mounted manager dispatches one `subscribeToDuelStates`
 query subscription. Its cache lifecycle obtains `POST /users/ticket`, constructs
 `{basePath}/users/connect?ticket=...` while forcing protocol `ws:`, closes any
 local prior socket, then constructs WebSocket. Tickets are random, stored on the
-user, overwritten by a new ticket, and consumed once; no expiry timestamp exists.
+user, and overwritten by a new ticket. Connect reads a matching ticket, clears
+it, and saves, but concurrent handlers can both read it before either clear is
+committed; no expiry timestamp exists.
 
 Ticket request or constructor failure schedules another full ticket/connect in
 3000 ms after clearing the previous timer. `onopen` clears that timer and
@@ -90,7 +94,7 @@ sequenceDiagram
     T->>B: connect same user
     B->>A: close "Replaced by new connection"
     B->>B: register Tab B socket
-    A->>B: old finally removes user entry and cancels pending duels
+    A->>B: old finally may remove user entry and cancel pending duels
     A-->>A: phase searching -> idle; interrupted modal
     Note over B,T: Tab B socket may stay open but no longer be registry target
 ```
@@ -104,10 +108,14 @@ changes only if a noncurrent envelope supplies it.
 
 ## Backend state assumptions
 
-Duely is authoritative and allows one registered socket/user. Disconnect always
-runs `CancelPendingDuels`; replacing a socket therefore affects matchmaking.
-Frontend assumes ticket response/string, flat event fields/enums, and server
-authorization of `SolutionUpdated`. No replay endpoint reconciles missed events.
+Duely is authoritative and keeps one process-local registered socket/user. On
+the ordinary handler-exit path, `finally` attempts to close the socket, remove
+the user registration, and send `CancelPendingDuels`. If current-socket
+`CloseAsync` throws, the later removal and pending cleanup can be skipped. An old
+handler can instead reach those statements after replacement and remove the new
+socket registration. Frontend assumes ticket response/string, flat event
+fields/enums, and server authorization of `SolutionUpdated`. No replay endpoint
+reconciles missed events.
 
 ## State ownership
 
@@ -150,16 +158,21 @@ casts assume backend names/fields remain compatible.
 ## Failure handling
 
 Ticket/constructor failures log and retry. Socket error alone logs; close needs
-manual reload. Malformed JSON/string payload is ignored. Unknown events are
-silent. Missed events rely on later HTTP refetch, but reconnect invalidation does
-not cover all real tags. Mixed-content `ws:` may prevent connection under HTTPS.
+manual reload. The backend's ordinary `finally` path attempts registration and
+pending-state cleanup, but process termination or an uncaught current-socket
+`CloseAsync` failure can prevent it. Malformed JSON/string payload is ignored.
+Unknown events are silent. Missed events rely on later HTTP refetch, but
+reconnect invalidation does not cover all real tags. Mixed-content `ws:` may
+prevent connection under HTTPS.
 
 ## Reload and multiple tabs
 
 Reload destroys/recreates socket with a new ticket and empty cache. Each tab
 opens its own socket and has independent timers/cache/sessionStorage but shared
-persisted Redux bytes. Backend replacement interrupts the old tab and cleanup
-can cancel search/remove the new registry entry. Tabs have no leader election.
+persisted Redux bytes. Backend replacement interrupts the old tab; if the old
+handler reaches cleanup after the new registration, it can cancel pending state
+and remove the new registry entry. Conversely, a close failure can skip that
+cleanup. Tabs have no leader election.
 
 ## Implementation references
 
@@ -167,7 +180,7 @@ can cancel search/remove the new registry entry. Tabs have no leader election.
 - `src/features/duel-session/ui/DuelSessionManager/DuelSessionManager.tsx`
 - `src/features/duel-session/lib/const.ts`
 - Backend `UserWebSocketHandler`, `WebSocketMessageSender`, message types
-- Backend docs: `../../../Backend/docs/processes/user-connection-lifecycle.md`
+- CoDuels-Backend: `docs/processes/user-connection-lifecycle.md`
 
 ## Test coverage
 
@@ -184,7 +197,9 @@ can cancel search/remove the new registry entry. Tabs have no leader election.
 Normal app tree has one subscription per tab; pre-open failures retry at 3000
 ms; open clears the scheduled timer; cache removal clears owned timers/socket;
 current flat backend event names listed as handled produce the documented
-mutations; code sync checks cached privacy flag and open readyState.
+mutations; code sync checks cached privacy flag and open readyState. These facts
+do not guarantee atomic single-use ticket consumption or backend cleanup after
+every connection termination.
 
 ## Open questions
 
@@ -196,6 +211,6 @@ cache reconciliation are unresolved.
 
 Use secure scheme derived from base URL; model socket state/generation; reconnect
 with backoff and replay cursor or full reconciliation; runtime-validate/version
-events; handle all backend message types; guarantee cleanup on unmount; elect a
-cross-tab owner or support multi-connection backend; and E2E-test replacement.
-
+events; handle all backend message types; add explicit frontend subscription
+cleanup on unmount; elect a cross-tab owner or support multi-connection backend;
+and E2E-test replacement.

--- a/docs/processes/reload-recovery-and-multiple-tabs.md
+++ b/docs/processes/reload-recovery-and-multiple-tabs.md
@@ -1,0 +1,154 @@
+# Reload recovery and multiple tabs
+
+## Purpose
+
+Explain what survives reload, what is revalidated, how browser storage scopes
+differ, and where independent tabs can conflict.
+
+## Participants
+
+redux-persist/localStorage, sessionStorage hooks, RTK Query, Router, auth and
+duel-session managers, editor/anti-cheat, Duely, browser lifecycle, and tabs.
+
+## Entry points
+
+Reload, close/reopen, duplicate/open another tab, back/forward/deep link, offline
+restart, logout/login, storage event from another tab, token refresh, socket
+replacement, and browser crash.
+
+## Preconditions
+
+Browser storage is available and contains parseable current-version data.
+PersistGate waits for Redux rehydration; stored data remains a provisional cache
+until backend queries/events confirm it.
+
+## Current behavior
+
+Redux localStorage keys are `persist:auth`, `persist:duelSession`,
+`persist:codeEditor`, and `persist:theme`, each version 1 with whitelists and no
+migration. Other localStorage keys include `duel-configurations` and
+`duel:{duelId}:resultDismissed`. Home sessionStorage keys are
+`home.showStartPanel`, `home.showConfigPicker`, `home.showConfigCreateModal`,
+`home.showFriendlyForm`, `home.friendlyNickname`, `home.selectedConfigId`,
+`home.selectedDefaultConfig`, `home.pendingInvitationNickname`,
+`home.waitingForStart`, and `home.pendingGroupInvitationId`. Duel UI also uses
+`duel.{duelId}.codeTab` and `duel-run-panel:{duelId}:{task}`.
+
+RTK cache, opponent code, session interruption, task snapshots, anti-cheat
+queue, socket, mutation state, and most forms do not survive. Home/run panel
+session values survive same-tab reload; run state may remain `running` without a
+run ID/resume mechanism. Custom storage hooks recover parse errors to initial
+values and silently ignore write errors. No BroadcastChannel/storage listener
+coordinates Redux. Backend currently permits one registered socket per user;
+the later tab replaces the earlier, and old cleanup can remove/cancel current
+state as detailed in [realtime connection](realtime-connection.md).
+
+```mermaid
+flowchart TD
+    reload["Reload active duel"] --> gate["PersistGate rehydrates auth/session/editor/theme"]
+    gate --> route["Router renders persisted route/session"]
+    gate --> empty["RTK cache, socket, opponent, snapshots empty"]
+    empty --> auth["getMe on protected route"]
+    empty --> socket["new ticket + WebSocket"]
+    route --> active{"activeDuelId/phase combination"}
+    active -- idle + ID --> restore["manager dispatches restore"]
+    active -- active + ID --> retained["no guaranteed global active-duel reconciliation"]
+    active -- searching + no ID --> reset["reset local phase to idle"]
+    auth --> queries["mounted pages refetch selectively"]
+    socket --> invalidate["partial tag invalidation"]
+```
+
+## Client state transitions
+
+Rehydration restores only whitelisted fields. Manager can restore active phase
+when an ID exists with idle; a thunk invocation inside an extraReducer is
+ineffective unless later dispatched by the manager. Reload resets searching/no
+active to idle without backend verification. New HTTP/events then overwrite
+parts of restored state.
+
+## Backend state assumptions
+
+Duely is authoritative for auth, pending/active duel, domain entities and socket
+ownership. Persisted client fields are not proof. Current reconciliation is
+selective: Home queries active duel, while direct routes or stale searching state
+do not always perform equivalent verification.
+
+## State ownership
+
+localStorage is origin-wide/shared across tabs; sessionStorage is tab-specific;
+React/RTK/socket/module state is process-specific; URL/history is browser-tab
+navigation; backend owns domain truth. No explicit arbiter merges these scopes.
+
+## UI effects
+
+PersistGate produces a blank gate until rehydrated. Stored phase/forms can show
+stale searching/waiting/modals. Empty RTK cache produces loaders/refetches.
+Another tab's logout, finish, role change, or code edit is not immediately
+reflected unless backend/socket/storage side effects happen to expose it.
+
+## Network effects
+
+Each tab independently calls `getMe`, opens a ticket/socket, subscribes queries,
+refreshes tokens, and sends code/actions. Socket open invalidation is incomplete.
+No cross-tab request leader exists, increasing duplicate starts/accepts/submits.
+
+## Idempotency and duplicate handling
+
+Reload can replay user actions manually but there is no durable mutation outbox
+or idempotency key. Persist writes are last-writer wins. Server queries are safe
+to repeat; domain mutations rely on backend duplicate handling.
+
+## Ordering assumptions
+
+Persist rehydration precedes child render, not backend truth. Tab storage writes,
+token refreshes, socket replacement/cleanup, HTTP responses, debounces, and
+events have no shared order or generation.
+
+## Failure handling
+
+Corrupt custom-storage values fall back; schemas/migrations are absent. Offline
+refresh can log out. Crash/unload loses queues and final code/status knowledge.
+There is no unified stale-session screen; the socket interruption modal offers
+full reload as recovery.
+
+## Reload and multiple tabs
+
+This process is inherently tab-sensitive. A second socket replaces the first;
+tabs retain independent Redux despite shared persistence bytes. Stale tabs may
+rewrite logged-out auth, old phase, source, or theme. sessionStorage waiting/form
+values can be shown under a subsequently logged-in different user.
+
+## Implementation references
+
+- `src/app/store.ts`, providers, router
+- auth/duelSession/codeEditor/theme persist configurations
+- `src/shared/lib/use{Local,Session}Storage.tsx`
+- Home, DuelInfo, CodePanel, run panel storage call sites
+- duel-session/auth API managers
+
+## Test coverage
+
+- **Existing tests:** none.
+- **Needed integration:** every whitelist/key/reset, corrupted/old schemas,
+  protected-route reconciliation, active/searching combinations, storage errors.
+- **Needed multi-context E2E:** two tabs login/logout/refresh/socket, edit/search/
+  accept/submit, reload each phase, offline/crash, duplicate tab, user switch.
+
+## Current guarantees
+
+Only documented whitelisted Redux fields are restored; RTK and in-memory queues
+start empty; same-tab sessionStorage normally survives reload; backend requests
+still re-authorize operations; editor code clears on local logout action.
+
+## Open questions
+
+Supported multi-tab model, socket ownership, storage user scoping/encryption/TTL,
+active/search reconciliation, stale-tab fencing, migrations, and recovery UX are
+unsettled.
+
+## Proposed requirements
+
+Treat restored state as explicitly unverified; reconcile auth/session globally;
+scope/version/purge all storage by user; coordinate tabs and socket leadership;
+fence stale writers; make mutations idempotent; test a formal reload/tab matrix.
+

--- a/docs/processes/rtk-query-cache.md
+++ b/docs/processes/rtk-query-cache.md
@@ -1,0 +1,143 @@
+# RTK Query cache
+
+## Purpose
+
+Catalog endpoint/cache ownership, tag topology, manual WebSocket/mutation
+patches, invalidation limits, and reconciliation expectations.
+
+## Participants
+
+Shared `apiSlice`, injected auth/user, duel/configuration/invitation, group,
+tournament, task, run, submission endpoints, React subscribers, WebSocket
+manager, redux-persist boundary, and Duely/Taski HTTP services.
+
+## Entry points
+
+Component query subscription, mutation, tag invalidation, manual
+`updateQueryData`, socket open/event, reload, logout/login, arg/filter change,
+cache eviction, and navigation.
+
+## Preconditions
+
+The API reducer/middleware are mounted. Auth header preparation reads current
+Redux token. Endpoint args serialize into cache keys; tag invalidation affects
+only active/provided matching tags and is not itself a domain-state update.
+
+## Current behavior
+
+The API slice is not persisted and uses normal RTK Query cache lifetime. Major
+families are:
+
+| Family | Representative operations | Important provided keys |
+| --- | --- | --- |
+| Auth/user | login/register/getMe/ticket | `User/ME` |
+| Configurations | list/detail/create/update/delete | entity IDs, `DuelConfiguration/LIST` |
+| Duels | search/cancel/active/list/detail | entity IDs, `Duel/LIST`, group-scoped keys |
+| Invitations | direct/group/tournament membership/duel actions | entities, `DuelInvitation/LIST`, `GroupInvitation/LIST` |
+| Groups | list/detail/users/create/roles/leave/invite | `Group/LIST`, group IDs |
+| Tournaments | group list/detail/create/start/accept | entity ID, `Tournament/GROUP-{id}` |
+| Tasks | task/statement/files | endpoint-argument caches |
+| Runs | start/status | duel/task/run argument caches |
+| Submissions | create/list/detail | item IDs, `Submission/LIST-{duelId}` |
+
+Mutations usually invalidate tags; several flows manually patch only caches that
+already exist. `getDuel.fulfilled` also writes editor/session slices outside the
+API cache. Socket open performs broad invalidation, but generic
+`Submission/LIST` and `Tournament/LIST` do not match actual provided list tags;
+`Duel/LIST` and `Group/LIST` omit several detail/scoped projections.
+
+## Client state transitions
+
+Queries move uninitialized/loading/success/error and retain data until eviction.
+Invalidation marks matching entries and refetches active subscriptions. Manual
+patches mutate snapshots synchronously but do not create absent query entries.
+Reload drops all entries; new subscriptions refetch.
+
+## Backend state assumptions
+
+Backend is authoritative. Tags assume a mutation/event fully identifies every
+projection made stale. Manual patches assume compatible DTO fields and event
+order. Neither assumption is enforced by schema versions or normalized global
+entities.
+
+## State ownership
+
+RTK owns received HTTP projections, request lifecycle, subscription/refetch, and
+tag metadata. Domain ownership stays backend-side. Persisted workflow/editor
+Redux and component/session state can outlive the API cache and disagree with a
+fresh response.
+
+## UI effects
+
+Active pages render cached data immediately and may refetch later. Invalidation
+does not guarantee immediate visible change: no matching tag/subscriber means no
+request. Manual patches can make one filter/detail current while sibling caches
+remain stale.
+
+## Network effects
+
+Subscriptions and matching invalidation issue HTTP requests; repeated broad
+invalidation can fan out. Socket event patches avoid a request but lose unknown
+entities. Logout does not dispatch `api.util.resetApiState`, so old-user cache
+can remain until component teardown/eviction and potentially flash for a new user.
+
+## Idempotency and duplicate handling
+
+RTK deduplicates concurrent identical query keys. Repeated invalidation/refetch
+is safe but costly. Manual patches implement their own item deduplication; lists
+with distinct serialized args remain independent. Mutations have no generic
+client idempotency.
+
+## Ordering assumptions
+
+HTTP responses, mutation invalidation, WebSocket patches, auth refresh/replay,
+and navigation are unordered. A late query can overwrite a newer event patch.
+Only the submission event path locally prevents terminal regression.
+
+## Failure handling
+
+Failed queries retain error/possibly prior data according to RTK behavior.
+ProtectedRoute can display Loader indefinitely for non-401 `getMe` errors.
+Manual patch exceptions/shape mismatches have no contract validation. Missing
+reconnect tags leave silently stale state.
+
+## Reload and multiple tabs
+
+Reload and each new tab start an empty API cache. Tabs never share invalidation
+or query responses. Persisted auth/session/editor can render decisions before
+new cache reconciliation. A socket in one tab cannot patch another tab's cache.
+
+## Implementation references
+
+- `src/shared/api/api.ts`
+- injected `*Api.ts` files under entities/features
+- `src/features/duel-session/api/duelSessionApi.ts`
+- `src/app/store.ts`
+- endpoint call sites in pages/widgets/features
+
+## Test coverage
+
+- **Existing tests/MSW handlers:** none.
+- **Needed integration:** endpoint-argument matrix, all provided/invalidated tag
+  pairs, late HTTP versus event, absent-cache patching, auth user switch/reset.
+- **Needed E2E:** reconnect while every page is open, reload, filtered submissions,
+  tournament finish, group invitation, stale detail, and multi-tab divergence.
+
+## Current guarantees
+
+Identical active query args share requests/cache within one store; reload cannot
+reuse stale API state; matching tag invalidation refetches active subscriptions;
+normal manual patches update only explicitly selected existing entries.
+
+## Open questions
+
+Cache retention, global reset on logout, normalized entity/version policy,
+reconnect reconciliation scope, tag naming convention, and acceptable request
+fanout are not documented as product requirements.
+
+## Proposed requirements
+
+Create a tested endpoint/tag matrix; align reconnect keys with provided tags;
+reset cache atomically on identity change; upsert/invalidate unknown events;
+version critical entities; define monotonic status merges; add MSW integration
+coverage before relying on manual cache surgery.

--- a/docs/processes/submissions.md
+++ b/docs/processes/submissions.md
@@ -1,0 +1,156 @@
+# Submissions
+
+## Purpose
+
+Describe solution submission, navigation, RTK list/detail representations, and
+reconciliation of asynchronous judging statuses delivered by WebSocket.
+
+## Participants
+
+Submit button/feature, CodePanel, task/submission pages, submission RTK API,
+duel-session WebSocket handlers, Duely, Taski/Exesh behind Duely, participant,
+and spectator.
+
+## Entry points
+
+Click submit, open submissions list or detail, change task filter, receive
+`SubmissionStatusUpdated`, reconnect/reload, revisit a duel, or finish it.
+
+## Preconditions
+
+The client has duel ID, task key (fallback `A`), nonempty solution, mapped
+language, and known participant permissions. Backend validates duel/task/user
+and owns acceptance. Downstream judging is asynchronous.
+
+## Current behavior
+
+Clicking submit first invokes `onSubmissionStart`, which navigates to submissions,
+then records anti-cheat actions and posts
+`POST /duels/:id/submissions` with `solution`, `language`, `task_key`. The awaited
+`.unwrap()` is not caught in the component handler. On fulfilled response, RTK
+manually prepends to the exact currently existing `{duelId, taskKey}` list and
+deduplicates by response `id`; this is post-response, not optimistic.
+
+List DTOs identify items as `submission_id`; detail/create use `id`. Cache keys
+separate filtered and unfiltered args. A WebSocket update iterates active list
+caches for the duel and patches a known ID plus detail; unknown submissions are
+not inserted or invalidated. Event patches prevent terminal `Done` from
+regressing, but normal HTTP merge/refetch has no equivalent terminal guard.
+Detail fetch updates only the unfiltered list. There is no polling.
+
+```mermaid
+sequenceDiagram
+    participant U as Participant
+    participant UI as Submit UI
+    participant D as Duely
+    participant C as RTK caches
+    participant J as Taski/Exesh
+    U->>UI: Submit
+    UI->>UI: Navigate + anti-cheat action
+    UI->>D: POST solution
+    D->>J: Start asynchronous judging
+    D-->>UI: Submission(id, Queued/Running)
+    UI->>C: Prepend only matching existing list
+    J-->>D: Status result
+    D-->>C: SubmissionStatusUpdated
+    alt Known cached ID
+        C->>C: Patch lists/detail; do not regress Done
+    else Event before list/create response
+        Note over C: Update is lost; no insert/invalidation
+    end
+```
+
+## Client state transitions
+
+Judging states are `Queued -> Running -> Done` in expected flow. Submit navigates
+before acceptance. Fulfilled create adds a cache item where present. Events
+patch existing items. Opening detail can recover its current state. RTK cache is
+lost on reload and reconstructed by queries.
+
+## Backend state assumptions
+
+Duely owns submission identity/access and exposes testing status derived from
+Taski/Exesh. The backend may accept a submission even if its response is lost.
+Status events may precede/follow any browser query. Terminal verdict/status is
+authoritative and should not regress.
+
+## State ownership
+
+Submission records/status belong to backend. RTK list/detail entries are
+independent projections keyed by endpoint arguments. Component mutation state
+owns the transient button. Editor owns submitted source before request; browser
+does not persist a submission outbox.
+
+## UI effects
+
+Participant is immediately moved to the submissions page. Empty/loading state
+disables normal repeats, although very fast duplicates are possible. Lists show
+status/verdict; detail is hidden from spectators in UI, while list/authors remain
+visible. Failed submit after navigation can leave the target list unchanged.
+
+## Network effects
+
+One authenticated POST creates; list/detail queries fetch; WebSocket drives
+status. Reconnect invalidates generic `Submission/LIST`, but actual lists provide
+`LIST-{duelId}`, so reconnect does not reliably refetch them.
+
+## Idempotency and duplicate handling
+
+No client idempotency key accompanies submission. Rapid/two-tab retries can
+create multiple real submissions. Cache insertion deduplicates known response
+ID. WebSocket duplicate events are mostly safe and terminal-protected; filtered
+caches can still diverge.
+
+## Ordering assumptions
+
+The implementation assumes create response populates cache before status event.
+It also assumes HTTP snapshots will not regress later event state, although only
+the event path enforces terminal protection. Detail/list response order and
+filtered caches are not versioned.
+
+## Failure handling
+
+A rejected `.unwrap()` is not caught locally. Lost successful response leaves no
+cache insertion but later list fetch can recover. Missed/early events remain
+stale without polling/matching invalidation. Unknown event IDs are ignored.
+
+## Reload and multiple tabs
+
+Reload loses submission cache and in-flight mutation knowledge; a fresh list can
+recover accepted items. Code draft survives. Tabs keep separate caches and can
+submit duplicates or display different statuses until independently refreshed.
+
+## Implementation references
+
+- submit-code feature under `src/features`
+- submission API/entity/pages/widgets under `src/entities/submission`
+- `src/features/duel-session/api/duelSessionApi.ts`
+- duel/task navigation widgets
+- Duely submission controllers/WebSocket messages
+
+## Test coverage
+
+- **Existing tests:** none.
+- **Needed integration:** all DTO ID shapes, filters/cache keys, status-before-
+  create, duplicates, terminal regression, unknown ID, reconnect invalidation.
+- **Needed E2E:** success/failure/response loss, reload/in-flight, spectator,
+  multiple tasks/tabs, delayed judging, and out-of-order statuses.
+
+## Current guarantees
+
+Normal accepted response is shown when the exact list cache exists; known
+WebSocket events update all enumerated active lists for that duel; event-only
+patching does not regress a cached `Done`; backend remains authoritative.
+
+## Open questions
+
+Submission idempotency, status revision/order, polling/reconnect strategy,
+filtered-cache normalization, spectator detail policy, and post-navigation error
+experience are not fully specified.
+
+## Proposed requirements
+
+Use an idempotency key and normalized entity cache; version statuses and enforce
+terminal monotonicity for every response path; upsert unknown events or
+invalidate; align reconnect tags; catch/show create failures; test reordering.
+

--- a/docs/processes/tournaments.md
+++ b/docs/processes/tournaments.md
@@ -1,0 +1,146 @@
+# Tournaments
+
+## Purpose
+
+Describe tournament creation, participant/configuration setup, start, bracket
+viewing, tournament-duel invitation acceptance, and duel-result refresh.
+
+## Participants
+
+Group tournament list/detail pages, four-step create form, Creator/Manager,
+participants, tournament RTK API, invitation aggregation, duel session, Duely,
+and WebSocket.
+
+## Entry points
+
+`/groups/:groupId/tournaments`, `/groups/:groupId/tournaments/:tournamentId`,
+create, start, accept a tournament duel from Home, open a duel, return/reload,
+and receive tournament invitation or duel-finished events.
+
+## Preconditions
+
+The user can access the group. Duely validates management permission, selected
+participants/configuration, matchmaking strategy, tournament status, and duel
+invitation eligibility. Status strings are `New`, `InProgress`, `Finished`;
+strategies include `SingleEliminationBracket` and `GroupStage`.
+
+## Current behavior
+
+Creation uses four component-state steps and posts participant nicknames plus
+configuration. Success invalidates the group tournament tag. Detail is cached by
+tournament ID; start invalidates both entity and group list. Start UI is visible
+for `New` to current Creator/Manager. A `TournamentDuelInvitation` invalidates
+duel-invitation data, not tournament detail. Acceptance invalidates tournament
+entity and invitations, then persists opponent/config/type/tournament ID,
+sets Home waiting, and awaits `DuelStarted`. Finishing a duel invalidates duel and
+current user, but not tournament tags; bracket data can remain stale. There is
+no automatic return to the originating tournament.
+
+```mermaid
+sequenceDiagram
+    participant M as Group manager
+    participant D as Duely tournament
+    participant P as Participant
+    participant T as RTK tournament cache
+    M->>D: Create then start tournament
+    D-->>T: HTTP responses/invalidation
+    D-->>P: TournamentDuelInvitation
+    P->>D: Accept tournament duel
+    D-->>P: Success then DuelStarted
+    P->>P: Navigate duel through local watcher
+    D-->>P: DuelFinished
+    Note over T: Current handler does not invalidate tournament
+    P->>T: Later remount/refetch may refresh bracket
+```
+
+## Client state transitions
+
+Form step/selection changes are local. Tournament DTO state changes only after
+query/mutation refresh. Accepted duel moves duelSession to searching then active.
+Tournament ID is persisted for cancellation matching, but a current generic
+cancellation event without that ID may fail to reset the state.
+
+## Backend state assumptions
+
+Duely owns bracket/group-stage scheduling, standings, invitation generation,
+status transitions, and permission. The client assumes returned bracket data is
+self-consistent and does not locally calculate advancement.
+
+## State ownership
+
+Tournament domain data is backend-owned and RTK-cached. Creation form is
+component state. Accepted duel context is split across persisted duelSession and
+Home sessionStorage. Route holds group/tournament identity; origin is not stored
+for post-duel navigation.
+
+## UI effects
+
+Pages render status/strategy/bracket and conditionally show start. Participants
+see tournament-duel invitations in Home. Stale detail can show an old round or
+status after another duel finishes until a refetch/remount or matching mutation.
+
+## Network effects
+
+Queries use entity ID and group-scoped tags. Create/start/accept mutate Duely.
+Reconnect invalidates generic `Tournament/LIST`, which does not match the
+provided entity or `GROUP-{id}` tags, so it does not guarantee bracket refresh.
+
+## Idempotency and duplicate handling
+
+No client idempotency keys cover create/start/accept. Buttons' loading state is
+the main duplicate guard. Repeated invalidation/refetch is safe; a repeated
+accept/start relies on backend state conflict handling.
+
+## Ordering assumptions
+
+The client assumes start response/refetch follows backend transition and accept
+response precedes `DuelStarted`. Tournament detail refresh is not ordered with
+`DuelFinished`; without invalidation, cached data can precede the result.
+
+## Failure handling
+
+Create form remains local on request failure; reload loses it. Start/accept
+errors surface through their UI paths. Lost accept response and missed events
+have no dedicated tournament-session reconciliation. Unknown cancellation does
+not reliably release a tournament waiting state.
+
+## Reload and multiple tabs
+
+Reload loses creation progress and RTK bracket cache, causing a fresh query.
+Accepted context persists partially; Home waiting is same-tab only. Tabs can
+start/accept concurrently and hold independently stale bracket caches.
+
+## Implementation references
+
+- tournament pages/features/entities under `src/pages/group` and
+  `src/entities/tournament`
+- `src/pages/home/ui/HomePage.tsx`
+- `src/features/duel-session/api/duelSessionApi.ts`
+- `src/features/duel-session/model/duelSessionSlice.ts`
+
+## Test coverage
+
+- **Existing tests:** none.
+- **Needed integration:** role/status matrix, both strategies, exact tags/events,
+  duplicate start/accept, bracket refresh after finish, cancellation fields.
+- **Needed E2E:** full create/start/round flow, participant acceptance, reload
+  each form step, post-duel bracket update, access revocation, and two tabs.
+
+## Current guarantees
+
+The client delegates bracket logic and authorization to Duely; successful
+create/start invalidates their intended current tags; acceptance retains the
+tournament ID; opening a detail after cache loss fetches current backend state.
+
+## Open questions
+
+Post-duel return, real-time bracket event, cancellation payload, tournament
+version/revision, form recovery, and idempotency of scheduling actions remain
+undefined.
+
+## Proposed requirements
+
+Push or invalidate a versioned tournament revision after every relevant duel;
+align reconnect tags; preserve explicit origin; include tournament/invitation ID
+in all events; and make create/start/accept idempotent and order-safe.
+


### PR DESCRIPTION
## Purpose

Document the current end-to-end Frontend behavior for user workflows, realtime events, client state, browser persistence, and cross-service contracts. The documents are intended to make implementation facts, unresolved product decisions, and proposed improvements independently reviewable.

## Documented components

- application bootstrap, routing, authentication, token refresh, Redux persistence, and RTK Query cache ownership;
- ranked, friendly, group, and tournament duel workflows;
- groups, tournaments, duel/task navigation, editor state, submissions, and code runs;
- the authenticated WebSocket lifecycle, reconnect/reload behavior, and multiple tabs;
- anti-cheat action capture and the contracts with Duely and Analyzer;
- Frontend-facing Duely, Taski, and Exesh assumptions.

## Scope

Production code is unchanged. This PR changes only Markdown documentation and repository guidance in `AGENTS.md`.

Each process keeps `Current behavior`, `Open questions`, and `Proposed requirements` separate. The consolidated risk table additionally distinguishes `Confirmed behavior`, `Confirmed defect`, `Confirmed contract mismatch`, `Potential risk`, and `Product decision required`.

## Five important risks

1. WebSocket ticket consumption is not atomic, backend cleanup is not guaranteed after every close, and an old handler can remove a newer tab's socket registration.
2. HTTP start/accept completion can race with `DuelStarted` and regress the persisted phase from `active` to `searching`.
3. Anti-cheat batches are memory-only and cleared without an acknowledgement/retry; Duely does not verify duel participation or task existence and does not deduplicate `EventId`.
4. Submission status events patch only existing caches, while reconnect invalidation does not match every real submission/tournament tag.
5. Persisted editor/session state has no revision or cross-tab ownership, so reload, user switch, refetch, and concurrent tabs can expose stale or conflicting state.

## Verification

- Rechecked routes, Redux fields and persist whitelists, browser-storage keys, RTK Query tags, HTTP endpoints, payload casing, enums, and WebSocket event names against source.
- Reconciled anti-cheat documentation with CoDuels-Backend `docs/processes/post-duel-anticheat.md` and its save/EF implementation.
- Reconciled WebSocket documentation with CoDuels-Backend `docs/processes/user-connection-lifecycle.md` and the ticket/handler implementation.
- Checked every Frontend Markdown file for broken internal and cross-repository relative links: no broken links remain.
- Checked required process headings, Mermaid fence pairing, classification labels, and `git diff --check`.

## Verification limitations

- This is a documentation-only PR, so `pnpm lint`, `pnpm fsd:lint`, and `pnpm build` were not run.
- The repository has no Frontend test script, process test suite, or configured Markdown linter.
- No browser E2E, multiple-tab, production HTTPS, network-failure, or live backend integration environment was exercised.
