### PR TITLE
fix(duel-session): make transitions monotonic

### DIFF
--- a/.github/workflows/frontend_pull_request.yml
+++ b/.github/workflows/frontend_pull_request.yml
@@ -1,33 +1,37 @@
 name: Frontend
 
 on:
-  pull_request:
-    branches:
-      - master
+    pull_request:
+        types: [opened, synchronize, reopened, ready_for_review]
+        branches: [master]
+
+permissions:
+    contents: read
 
 jobs:
-  check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Lint
-        run: pnpm lint
-      - name: Check Feature-Sliced Design boundaries
-        # The current codebase has pre-existing FSD violations; keep reporting them
-        # without blocking unrelated changes until a dedicated cleanup is merged.
-        continue-on-error: true
-        run: pnpm fsd:lint
-      - name: Build
-        run: pnpm build
+    check:
+        if: ${{ github.event.pull_request.draft == false }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+              with:
+                  version: 10
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+                  cache: pnpm
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+            - name: Lint
+              run: pnpm lint
+            - name: Check Feature-Sliced Design boundaries
+              # The current codebase has pre-existing FSD violations; keep reporting them
+              # without blocking unrelated changes until a dedicated cleanup is merged.
+              continue-on-error: true
+              run: pnpm fsd:lint
+            - name: Build
+              run: pnpm build

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
         "build": "tsc -b && vite build",
         "lint": "tsc && eslint .",
         "lint:fix": "eslint . --fix",
+        "test": "vitest run",
         "preview": "vite preview",
         "fsd:lint": "steiger ./src",
         "prettier:fix": "prettier --write ./src",
@@ -62,7 +63,8 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.48.0",
         "vite": "^7.2.4",
-        "vite-plugin-svgr": "^4.5.0"
+        "vite-plugin-svgr": "^4.5.0",
+        "vitest": "^4.1.10"
     },
     "lint-staged": {
         "*": "prettier --write --ignore-unknown",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
             vite-plugin-svgr:
                 specifier: ^4.5.0
                 version: 4.5.0(rollup@4.53.3)(typescript@5.9.3)(vite@7.2.4(sass@1.94.2)(yaml@2.8.1))
+            vitest:
+                specifier: ^4.1.10
+                version: 4.1.10(msw@2.12.3(typescript@5.9.3))(vite@7.2.4(sass@1.94.2)(yaml@2.8.1))
 
 packages:
     "@babel/code-frame@7.27.1":
@@ -1254,6 +1257,12 @@ packages:
                 integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==,
             }
 
+    "@standard-schema/spec@1.1.0":
+        resolution:
+            {
+                integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+            }
+
     "@standard-schema/utils@0.3.0":
         resolution:
             {
@@ -1394,10 +1403,22 @@ packages:
                 integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==,
             }
 
+    "@types/chai@5.2.3":
+        resolution:
+            {
+                integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==,
+            }
+
     "@types/debug@4.1.12":
         resolution:
             {
                 integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==,
+            }
+
+    "@types/deep-eql@4.0.2":
+        resolution:
+            {
+                integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
             }
 
     "@types/estree-jsx@1.0.5":
@@ -1586,6 +1607,7 @@ packages:
             {
                 integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
             }
+        deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
     "@unrs/resolver-binding-android-arm-eabi@1.11.1":
         resolution:
@@ -1748,6 +1770,56 @@ packages:
         peerDependencies:
             vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+    "@vitest/expect@4.1.10":
+        resolution:
+            {
+                integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==,
+            }
+
+    "@vitest/mocker@4.1.10":
+        resolution:
+            {
+                integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==,
+            }
+        peerDependencies:
+            msw: ^2.4.9
+            vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+        peerDependenciesMeta:
+            msw:
+                optional: true
+            vite:
+                optional: true
+
+    "@vitest/pretty-format@4.1.10":
+        resolution:
+            {
+                integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==,
+            }
+
+    "@vitest/runner@4.1.10":
+        resolution:
+            {
+                integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==,
+            }
+
+    "@vitest/snapshot@4.1.10":
+        resolution:
+            {
+                integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==,
+            }
+
+    "@vitest/spy@4.1.10":
+        resolution:
+            {
+                integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==,
+            }
+
+    "@vitest/utils@4.1.10":
+        resolution:
+            {
+                integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==,
+            }
+
     "@vue/compiler-core@3.5.25":
         resolution:
             {
@@ -1883,6 +1955,13 @@ packages:
             }
         engines: { node: ">= 0.4" }
 
+    assertion-error@2.0.1:
+        resolution:
+            {
+                integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==,
+            }
+        engines: { node: ">=12" }
+
     ast-module-types@6.0.1:
         resolution:
             {
@@ -2008,6 +2087,13 @@ packages:
             {
                 integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
             }
+
+    chai@6.2.2:
+        resolution:
+            {
+                integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==,
+            }
+        engines: { node: ">=18" }
 
     chalk@4.1.2:
         resolution:
@@ -2458,6 +2544,12 @@ packages:
             }
         engines: { node: ">= 0.4" }
 
+    es-module-lexer@2.3.1:
+        resolution:
+            {
+                integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==,
+            }
+
     es-object-atoms@1.1.1:
         resolution:
             {
@@ -2706,6 +2798,12 @@ packages:
                 integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
             }
 
+    estree-walker@3.0.3:
+        resolution:
+            {
+                integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==,
+            }
+
     esutils@2.0.3:
         resolution:
             {
@@ -2718,6 +2816,13 @@ packages:
             {
                 integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==,
             }
+
+    expect-type@1.4.0:
+        resolution:
+            {
+                integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==,
+            }
+        engines: { node: ">=12.0.0" }
 
     extend@3.0.2:
         resolution:
@@ -3968,6 +4073,13 @@ packages:
             }
         engines: { node: ">= 0.4" }
 
+    obug@2.1.4:
+        resolution:
+            {
+                integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==,
+            }
+        engines: { node: ">=12.20.0" }
+
     onetime@7.0.0:
         resolution:
             {
@@ -4074,6 +4186,12 @@ packages:
                 integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==,
             }
         engines: { node: ">=18" }
+
+    pathe@2.0.3:
+        resolution:
+            {
+                integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
+            }
 
     patronum@2.3.0:
         resolution:
@@ -4565,6 +4683,12 @@ packages:
             }
         engines: { node: ">= 0.4" }
 
+    siginfo@2.0.0:
+        resolution:
+            {
+                integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==,
+            }
+
     signal-exit@4.1.0:
         resolution:
             {
@@ -4631,6 +4755,12 @@ packages:
             }
         engines: { node: ">=12.0.0" }
 
+    stackback@0.0.2:
+        resolution:
+            {
+                integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==,
+            }
+
     state-local@1.0.7:
         resolution:
             {
@@ -4643,6 +4773,12 @@ packages:
                 integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==,
             }
         engines: { node: ">= 0.8" }
+
+    std-env@4.2.0:
+        resolution:
+            {
+                integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==,
+            }
 
     steiger@0.5.11:
         resolution:
@@ -4799,12 +4935,32 @@ packages:
             }
         engines: { node: ">=20" }
 
+    tinybench@2.9.0:
+        resolution:
+            {
+                integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
+            }
+
+    tinyexec@1.2.4:
+        resolution:
+            {
+                integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==,
+            }
+        engines: { node: ">=18" }
+
     tinyglobby@0.2.15:
         resolution:
             {
                 integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
             }
         engines: { node: ">=12.0.0" }
+
+    tinyrainbow@3.1.0:
+        resolution:
+            {
+                integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
+            }
+        engines: { node: ">=14.0.0" }
 
     tldts-core@7.0.19:
         resolution:
@@ -4874,6 +5030,7 @@ packages:
                 integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==,
             }
         engines: { node: ^18 || >=20 }
+        deprecated: unmaintained
         hasBin: true
         peerDependencies:
             typescript: ^5.0.0
@@ -5128,6 +5285,50 @@ packages:
             yaml:
                 optional: true
 
+    vitest@4.1.10:
+        resolution:
+            {
+                integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==,
+            }
+        engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
+        hasBin: true
+        peerDependencies:
+            "@edge-runtime/vm": "*"
+            "@opentelemetry/api": ^1.9.0
+            "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+            "@vitest/browser-playwright": 4.1.10
+            "@vitest/browser-preview": 4.1.10
+            "@vitest/browser-webdriverio": 4.1.10
+            "@vitest/coverage-istanbul": 4.1.10
+            "@vitest/coverage-v8": 4.1.10
+            "@vitest/ui": 4.1.10
+            happy-dom: "*"
+            jsdom: "*"
+            vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+        peerDependenciesMeta:
+            "@edge-runtime/vm":
+                optional: true
+            "@opentelemetry/api":
+                optional: true
+            "@types/node":
+                optional: true
+            "@vitest/browser-playwright":
+                optional: true
+            "@vitest/browser-preview":
+                optional: true
+            "@vitest/browser-webdriverio":
+                optional: true
+            "@vitest/coverage-istanbul":
+                optional: true
+            "@vitest/coverage-v8":
+                optional: true
+            "@vitest/ui":
+                optional: true
+            happy-dom:
+                optional: true
+            jsdom:
+                optional: true
+
     web-namespaces@2.0.1:
         resolution:
             {
@@ -5168,6 +5369,14 @@ packages:
                 integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
             }
         engines: { node: ">= 8" }
+        hasBin: true
+
+    why-is-node-running@2.3.0:
+        resolution:
+            {
+                integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==,
+            }
+        engines: { node: ">=8" }
         hasBin: true
 
     word-wrap@1.2.5:
@@ -5902,6 +6111,8 @@ snapshots:
 
     "@standard-schema/spec@1.0.0": {}
 
+    "@standard-schema/spec@1.1.0": {}
+
     "@standard-schema/utils@0.3.0": {}
 
     "@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.5)":
@@ -6000,9 +6211,16 @@ snapshots:
         dependencies:
             "@babel/types": 7.28.5
 
+    "@types/chai@5.2.3":
+        dependencies:
+            "@types/deep-eql": 4.0.2
+            assertion-error: 2.0.1
+
     "@types/debug@4.1.12":
         dependencies:
             "@types/ms": 2.1.0
+
+    "@types/deep-eql@4.0.2": {}
 
     "@types/estree-jsx@1.0.5":
         dependencies:
@@ -6209,6 +6427,48 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
+    "@vitest/expect@4.1.10":
+        dependencies:
+            "@standard-schema/spec": 1.1.0
+            "@types/chai": 5.2.3
+            "@vitest/spy": 4.1.10
+            "@vitest/utils": 4.1.10
+            chai: 6.2.2
+            tinyrainbow: 3.1.0
+
+    "@vitest/mocker@4.1.10(msw@2.12.3(typescript@5.9.3))(vite@7.2.4(sass@1.94.2)(yaml@2.8.1))":
+        dependencies:
+            "@vitest/spy": 4.1.10
+            estree-walker: 3.0.3
+            magic-string: 0.30.21
+        optionalDependencies:
+            msw: 2.12.3(typescript@5.9.3)
+            vite: 7.2.4(sass@1.94.2)(yaml@2.8.1)
+
+    "@vitest/pretty-format@4.1.10":
+        dependencies:
+            tinyrainbow: 3.1.0
+
+    "@vitest/runner@4.1.10":
+        dependencies:
+            "@vitest/utils": 4.1.10
+            pathe: 2.0.3
+
+    "@vitest/snapshot@4.1.10":
+        dependencies:
+            "@vitest/pretty-format": 4.1.10
+            "@vitest/utils": 4.1.10
+            magic-string: 0.30.21
+            pathe: 2.0.3
+
+    "@vitest/spy@4.1.10": {}
+
+    "@vitest/utils@4.1.10":
+        dependencies:
+            "@vitest/pretty-format": 4.1.10
+            convert-source-map: 2.0.0
+            tinyrainbow: 3.1.0
+
     "@vue/compiler-core@3.5.25":
         dependencies:
             "@babel/parser": 7.28.5
@@ -6320,6 +6580,8 @@ snapshots:
             get-intrinsic: 1.3.0
             is-array-buffer: 3.0.5
 
+    assertion-error@2.0.1: {}
+
     ast-module-types@6.0.1: {}
 
     async-function@1.0.0: {}
@@ -6385,6 +6647,8 @@ snapshots:
     caniuse-lite@1.0.30001757: {}
 
     ccount@2.0.1: {}
+
+    chai@6.2.2: {}
 
     chalk@4.1.2:
         dependencies:
@@ -6679,6 +6943,8 @@ snapshots:
 
     es-errors@1.3.0: {}
 
+    es-module-lexer@2.3.1: {}
+
     es-object-atoms@1.1.1:
         dependencies:
             es-errors: 1.3.0
@@ -6928,9 +7194,15 @@ snapshots:
 
     estree-walker@2.0.2: {}
 
+    estree-walker@3.0.3:
+        dependencies:
+            "@types/estree": 1.0.8
+
     esutils@2.0.3: {}
 
     eventemitter3@5.0.1: {}
+
+    expect-type@1.4.0: {}
 
     extend@3.0.2: {}
 
@@ -7811,6 +8083,8 @@ snapshots:
             define-properties: 1.2.1
             es-object-atoms: 1.1.1
 
+    obug@2.1.4: {}
+
     onetime@7.0.0:
         dependencies:
             mimic-function: 5.0.1
@@ -7876,6 +8150,8 @@ snapshots:
     path-type@4.0.0: {}
 
     path-type@6.0.0: {}
+
+    pathe@2.0.3: {}
 
     patronum@2.3.0(effector@23.4.4):
         dependencies:
@@ -8231,6 +8507,8 @@ snapshots:
             side-channel-map: 1.0.1
             side-channel-weakmap: 1.0.2
 
+    siginfo@2.0.0: {}
+
     signal-exit@4.1.0: {}
 
     sisteransi@1.0.5: {}
@@ -8258,9 +8536,13 @@ snapshots:
 
     stable-hash-x@0.2.0: {}
 
+    stackback@0.0.2: {}
+
     state-local@1.0.7: {}
 
     statuses@2.0.2: {}
+
+    std-env@4.2.0: {}
 
     steiger@0.5.11(typescript@5.9.3):
         dependencies:
@@ -8373,10 +8655,16 @@ snapshots:
 
     tagged-tag@1.0.0: {}
 
+    tinybench@2.9.0: {}
+
+    tinyexec@1.2.4: {}
+
     tinyglobby@0.2.15:
         dependencies:
             fdir: 6.5.0(picomatch@4.0.3)
             picomatch: 4.0.3
+
+    tinyrainbow@3.1.0: {}
 
     tldts-core@7.0.19: {}
 
@@ -8609,6 +8897,31 @@ snapshots:
             sass: 1.94.2
             yaml: 2.8.1
 
+    vitest@4.1.10(msw@2.12.3(typescript@5.9.3))(vite@7.2.4(sass@1.94.2)(yaml@2.8.1)):
+        dependencies:
+            "@vitest/expect": 4.1.10
+            "@vitest/mocker": 4.1.10(msw@2.12.3(typescript@5.9.3))(vite@7.2.4(sass@1.94.2)(yaml@2.8.1))
+            "@vitest/pretty-format": 4.1.10
+            "@vitest/runner": 4.1.10
+            "@vitest/snapshot": 4.1.10
+            "@vitest/spy": 4.1.10
+            "@vitest/utils": 4.1.10
+            es-module-lexer: 2.3.1
+            expect-type: 1.4.0
+            magic-string: 0.30.21
+            obug: 2.1.4
+            pathe: 2.0.3
+            picomatch: 4.0.3
+            std-env: 4.2.0
+            tinybench: 2.9.0
+            tinyexec: 1.2.4
+            tinyglobby: 0.2.15
+            tinyrainbow: 3.1.0
+            vite: 7.2.4(sass@1.94.2)(yaml@2.8.1)
+            why-is-node-running: 2.3.0
+        transitivePeerDependencies:
+            - msw
+
     web-namespaces@2.0.1: {}
 
     which-boxed-primitive@1.1.1:
@@ -8655,6 +8968,11 @@ snapshots:
     which@2.0.2:
         dependencies:
             isexe: 2.0.0
+
+    why-is-node-running@2.3.0:
+        dependencies:
+            siginfo: 2.0.0
+            stackback: 0.0.2
 
     word-wrap@1.2.5: {}
 

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -17,10 +17,13 @@ const authPersistConfig = {
 const duelSessionPersistConfig = {
     key: "duelSession",
     storage,
-    version: 1,
+    version: 2,
     whitelist: [
         "activeDuelId",
+        "generation",
         "lastEventId",
+        "lastServerRevision",
+        "recentEventIds",
         "phase",
         "searchNickname",
         "searchConfigurationId",

--- a/src/entities/duel/api/duelApi.ts
+++ b/src/entities/duel/api/duelApi.ts
@@ -1,6 +1,9 @@
 import { apiSlice } from "shared/api";
 
-import { Duel, GroupDuelEntry } from "../model/types";
+import { ActiveDuelResponse, Duel, GroupDuelEntry } from "../model/types";
+
+export const getActiveDuelId = (response: ActiveDuelResponse) =>
+    "duel_id" in response ? response.duel_id : response.id;
 
 export const duelApiSlice = apiSlice.injectEndpoints({
     endpoints: (builder) => ({
@@ -18,9 +21,11 @@ export const duelApiSlice = apiSlice.injectEndpoints({
                       ]
                     : [{ type: "Duel", id: "LIST" }],
         }),
-        getActiveDuel: builder.query<Duel, void>({
+        getActiveDuel: builder.query<ActiveDuelResponse, void>({
             query: () => `/duels/active`,
-            providesTags: (result) => [{ type: "Duel", id: result?.id ?? "ACTIVE" }],
+            providesTags: (result) => [
+                { type: "Duel", id: result ? (getActiveDuelId(result) ?? "ACTIVE") : "ACTIVE" },
+            ],
         }),
         getGroupDuels: builder.query<GroupDuelEntry[], number>({
             query: (groupId) => `/groups/${groupId}/duels`,

--- a/src/entities/duel/index.ts
+++ b/src/entities/duel/index.ts
@@ -1,4 +1,4 @@
-export { duelApiSlice } from "./api/duelApi";
+export { duelApiSlice, getActiveDuelId } from "./api/duelApi";
 
 export {
     useGetDuelQuery,
@@ -10,7 +10,13 @@ export {
 export { DuelResult } from "./ui/DuelResult/DuelResult";
 export { DuelHistory } from "./ui/DuelHistory/DuelHistory";
 
-export type { DuelResultType, Duel, DuelTaskRef } from "./model/types";
+export type {
+    ActiveDuelReference,
+    ActiveDuelResponse,
+    DuelResultType,
+    Duel,
+    DuelTaskRef,
+} from "./model/types";
 
 export { getDuelResultForUser } from "./lib/duelResultHelpers";
 export { useDuelTaskSelection } from "./lib/useDuelTaskSelection";

--- a/src/entities/duel/model/types.ts
+++ b/src/entities/duel/model/types.ts
@@ -34,6 +34,12 @@ export interface Duel {
     task_id?: string;
 }
 
+export interface ActiveDuelReference {
+    duel_id: number | null;
+}
+
+export type ActiveDuelResponse = Duel | ActiveDuelReference;
+
 export interface GroupDuelEntry {
     duel: Duel | null;
     configuration_id?: number | null;

--- a/src/features/duel-session/api/duelSessionApi.ts
+++ b/src/features/duel-session/api/duelSessionApi.ts
@@ -10,17 +10,16 @@ import { fromApiLanguage, LANGUAGES, toApiLanguage } from "shared/config";
 import { buildDuelTaskKey } from "widgets/code-panel/lib/duelTaskKey";
 import { setCode, setLanguage, setOpponentCode } from "widgets/code-panel/model/codeEditorSlice";
 import {
-    setActiveDuelId,
+    applyDuelSearchCanceled,
+    completeFinishedDuel,
+    markDuelFinished,
+    markDuelSessionInterrupted,
     setDuelCanceled,
     setDuelCanceledOpponentNickname,
-    setPhase,
     setLastEventId,
-    setSearchInvitationType,
-    setSearchTournamentId,
-    setSessionInterrupted,
-    resetDuelSession,
 } from "../model/duelSessionSlice";
-import { DuelMessage } from "../model/types";
+import { confirmDuelStartedFromServer, reconcileDuelSession } from "../model/thunks";
+import type { DuelMessage, DuelSessionEventMetadata } from "../model/types";
 import { WS_RETRY_TIMEOUT } from "../lib/const";
 
 const buildUserConnectUrl = (ticket: string) => {
@@ -44,13 +43,41 @@ type DuelSocketEnvelope = {
     payload?: unknown;
     lastEventId?: string;
     last_event_id?: string;
+    eventId?: string;
+    event_id?: string;
+    revision?: number | string;
+    serverRevision?: number | string;
+    server_revision?: number | string;
+    generation?: string;
+    sessionGeneration?: string;
+    session_generation?: string;
 };
 
 const extractEventName = (envelope: DuelSocketEnvelope) =>
     envelope.event ?? envelope.type ?? envelope.name ?? null;
 
 const extractLastEventId = (envelope: DuelSocketEnvelope) =>
-    envelope.lastEventId ?? envelope.last_event_id ?? null;
+    envelope.eventId ?? envelope.event_id ?? envelope.lastEventId ?? envelope.last_event_id ?? null;
+
+const extractEventMetadata = (envelope: DuelSocketEnvelope): DuelSessionEventMetadata => {
+    const rawRevision = envelope.revision ?? envelope.serverRevision ?? envelope.server_revision;
+    const revision =
+        typeof rawRevision === "number"
+            ? rawRevision
+            : typeof rawRevision === "string" && rawRevision.trim() !== ""
+              ? Number(rawRevision)
+              : null;
+
+    return {
+        eventId: extractLastEventId(envelope),
+        generation:
+            envelope.generation ??
+            envelope.sessionGeneration ??
+            envelope.session_generation ??
+            null,
+        revision: revision != null && Number.isFinite(revision) ? revision : null,
+    };
+};
 
 const normalizeEventName = (eventName: string) => eventName.replace(/[^a-zA-Z]/g, "").toLowerCase();
 
@@ -320,15 +347,16 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
 
                     const duelStartedListener = (
                         payload: DuelMessage | null,
-                        lastEventId: string | null,
+                        metadata: DuelSessionEventMetadata,
                     ) => {
                         if (!payload) return;
 
-                        dispatch(setActiveDuelId(payload.duel_id));
-
-                        if (lastEventId) {
-                            dispatch(setLastEventId(lastEventId));
-                        }
+                        void dispatch(
+                            confirmDuelStartedFromServer({
+                                duelId: payload.duel_id,
+                                metadata,
+                            }),
+                        );
 
                         dispatch(
                             duelApiSlice.util.invalidateTags([
@@ -339,26 +367,41 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
 
                     const duelFinishedListener = (
                         payload: DuelMessage | null,
-                        lastEventId: string | null,
+                        metadata: DuelSessionEventMetadata,
                     ) => {
                         if (!payload) return;
 
-                        if (lastEventId) {
-                            dispatch(setLastEventId(lastEventId));
-                        }
+                        const duelId = payload.duel_id;
+                        const previousSession = (getState() as RootState).duelSession;
+                        const expectedGeneration = previousSession.generation;
+                        dispatch(markDuelFinished({ duelId, expectedGeneration, ...metadata }));
 
-                        const duelId =
-                            payload.duel_id ??
-                            (getState() as RootState).duelSession.activeDuelId ??
-                            null;
-
-                        dispatch(setPhase("idle"));
-                        dispatch(resetDuelSession());
-
-                        if (duelId) {
-                            dispatch(
-                                duelApiSlice.util.invalidateTags([{ type: "Duel", id: duelId }]),
+                        const currentSession = (getState() as RootState).duelSession;
+                        if (
+                            previousSession.phase === "active" &&
+                            previousSession.activeDuelId === duelId &&
+                            currentSession.phase === "finished" &&
+                            currentSession.activeDuelId === duelId &&
+                            currentSession.generation === expectedGeneration
+                        ) {
+                            const resultRequest = dispatch(
+                                duelApiSlice.endpoints.getDuel.initiate(duelId, {
+                                    forceRefetch: true,
+                                    subscribe: false,
+                                }),
                             );
+
+                            void resultRequest
+                                .unwrap()
+                                .then(() => {
+                                    dispatch(
+                                        completeFinishedDuel({
+                                            duelId,
+                                            generation: expectedGeneration,
+                                        }),
+                                    );
+                                })
+                                .catch(() => undefined);
                         }
 
                         dispatch(userApiSlice.util.invalidateTags([{ type: "User", id: "ME" }]));
@@ -366,14 +409,20 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
 
                     const duelCanceledListener = (
                         payload: { opponent_nickname?: string | null } | null,
-                        lastEventId: string | null,
+                        metadata: DuelSessionEventMetadata,
                     ) => {
-                        if (lastEventId) {
-                            dispatch(setLastEventId(lastEventId));
-                        }
+                        const currentSession = (getState() as RootState).duelSession;
+                        dispatch(
+                            applyDuelSearchCanceled({
+                                expectedGeneration: currentSession.generation,
+                                ...metadata,
+                            }),
+                        );
+                        const wasApplied =
+                            currentSession.phase !== "idle" &&
+                            (getState() as RootState).duelSession.phase === "idle";
+                        if (!wasApplied) return;
 
-                        dispatch(setPhase("idle"));
-                        dispatch(resetDuelSession());
                         dispatch(
                             setDuelCanceledOpponentNickname(payload?.opponent_nickname ?? null),
                         );
@@ -395,6 +444,30 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
                                 duelApiSlice.util.invalidateTags([{ type: "Duel", id: duelId }]),
                             );
                         }
+                    };
+
+                    const applyMatchingSearchCancellation = (
+                        invitationPayload: {
+                            opponent_nickname?: string | null;
+                            configuration_id?: number | null;
+                            tournament_id?: number | null;
+                        } | null,
+                        metadata: DuelSessionEventMetadata,
+                    ) => {
+                        const currentState = getState() as RootState;
+                        if (!matchInvitationPayload(invitationPayload, currentState)) return false;
+
+                        const currentSession = currentState.duelSession;
+                        dispatch(
+                            applyDuelSearchCanceled({
+                                expectedGeneration: currentSession.generation,
+                                ...metadata,
+                            }),
+                        );
+                        return (
+                            currentSession.phase !== "idle" &&
+                            (getState() as RootState).duelSession.phase === "idle"
+                        );
                     };
 
                     const closeSocket = () => {
@@ -438,6 +511,7 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
 
                         const eventName = extractEventName(parsed);
                         const lastEventId = extractLastEventId(parsed);
+                        const eventMetadata = extractEventMetadata(parsed);
                         const rawPayload =
                             parsed.data ?? parsed.payload ?? (parsed as unknown as DuelMessage);
                         let payload: unknown = rawPayload;
@@ -451,10 +525,6 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
                             }
                         }
 
-                        if (lastEventId) {
-                            dispatch(setLastEventId(lastEventId));
-                        }
-
                         if (!eventName) {
                             if (payload && typeof payload === "object" && "duel_id" in payload) {
                                 duelChangedListener(payload as DuelMessage, lastEventId);
@@ -465,19 +535,19 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
                         const normalized = normalizeEventName(eventName);
 
                         if (normalized === "duelstarted") {
-                            duelStartedListener(payload as DuelMessage, lastEventId);
+                            duelStartedListener(payload as DuelMessage, eventMetadata);
                             return;
                         }
 
                         if (normalized === "duelfinished") {
-                            duelFinishedListener(payload as DuelMessage, lastEventId);
+                            duelFinishedListener(payload as DuelMessage, eventMetadata);
                             return;
                         }
 
                         if (normalized === "duelcanceled") {
                             duelCanceledListener(
                                 payload as { opponent_nickname?: string | null },
-                                lastEventId,
+                                eventMetadata,
                             );
                             return;
                         }
@@ -519,16 +589,13 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
                                 ]),
                             );
 
-                            const currentState = getState() as RootState;
                             const invitationPayload = payload as {
                                 opponent_nickname?: string | null;
                                 configuration_id?: number | null;
                                 tournament_id?: number | null;
                             } | null;
 
-                            if (matchInvitationPayload(invitationPayload, currentState)) {
-                                dispatch(setPhase("idle"));
-                            }
+                            applyMatchingSearchCancellation(invitationPayload, eventMetadata);
                             return;
                         }
 
@@ -542,16 +609,13 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
                                 ]),
                             );
 
-                            const currentState = getState() as RootState;
                             const invitationPayload = payload as {
                                 opponent_nickname?: string | null;
                                 configuration_id?: number | null;
                                 tournament_id?: number | null;
                             } | null;
 
-                            if (matchInvitationPayload(invitationPayload, currentState)) {
-                                dispatch(setPhase("idle"));
-                            }
+                            applyMatchingSearchCancellation(invitationPayload, eventMetadata);
                             return;
                         }
 
@@ -571,15 +635,13 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
                                 ]),
                             );
 
-                            const currentState = getState() as RootState;
                             const invitationPayload = payload as {
                                 opponent_nickname?: string | null;
                                 configuration_id?: number | null;
                                 tournament_id?: number | null;
                             } | null;
 
-                            if (matchInvitationPayload(invitationPayload, currentState)) {
-                                dispatch(setPhase("idle"));
+                            if (applyMatchingSearchCancellation(invitationPayload, eventMetadata)) {
                                 dispatch(
                                     setDuelCanceledOpponentNickname(
                                         invitationPayload?.opponent_nickname ?? null,
@@ -741,7 +803,7 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
 
                         socket.onopen = () => {
                             clearReconnectTimeout();
-                            dispatch(setSessionInterrupted(false));
+                            void dispatch(reconcileDuelSession());
                             dispatch(
                                 apiSlice.util.invalidateTags([
                                     { type: "Duel", id: "LIST" },
@@ -764,15 +826,8 @@ export const duelSessionApiSlice = apiSlice.injectEndpoints({
 
                         socket.onclose = () => {
                             const latestState = getState() as RootState;
-
-                            if (latestState.duelSession.phase === "searching") {
-                                dispatch(setPhase("idle"));
-                                dispatch(setSearchInvitationType(null));
-                                dispatch(setSearchTournamentId(null));
-                            }
-
                             if (!latestState.auth.token) return;
-                            dispatch(setSessionInterrupted(true));
+                            dispatch(markDuelSessionInterrupted());
                         };
                     };
 

--- a/src/features/duel-session/index.ts
+++ b/src/features/duel-session/index.ts
@@ -12,7 +12,17 @@ export { DuelSessionManager } from "./ui/DuelSessionManager/DuelSessionManager";
 export { DuelInfo } from "./ui/DuelInfo/DuelInfo";
 
 export {
+    beginDuelConfiguration,
+    beginDuelSearch,
+    confirmDuelSearch,
+    failDuelSearch,
+    finishDuelConfiguration,
     resetDuelSession,
+    setDuelCanceled,
     setDuelStatusChanged,
     setOpenedTaskKeys,
+    setSearchConfigurationId,
+    setSearchInvitationType,
+    setSearchNickname,
+    setSearchTournamentId,
 } from "./model/duelSessionSlice";

--- a/src/features/duel-session/model/duelSessionSlice.test.ts
+++ b/src/features/duel-session/model/duelSessionSlice.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import duelSessionReducer, {
+    applyDuelSearchCanceled,
+    beginDuelSearch,
+    beginDuelSearchCancellation,
+    beginDuelSessionRestore,
+    completeFinishedDuel,
+    confirmDuelSearch,
+    confirmDuelSearchCancellation,
+    confirmDuelStarted,
+    failDuelSearch,
+    markDuelFinished,
+    markDuelSessionInterrupted,
+    reconcileDuelSessionSucceeded,
+} from "./duelSessionSlice";
+import type { DuelSearchContext, DuelSessionState } from "./types";
+
+vi.mock("entities/duel", () => ({
+    duelApiSlice: {
+        endpoints: {
+            getDuel: {
+                matchFulfilled: () => false,
+            },
+        },
+    },
+}));
+
+const rankedContext: DuelSearchContext = {
+    nickname: null,
+    configurationId: null,
+    invitationType: "Ranked",
+    tournamentId: null,
+};
+
+const reduce = (
+    state: DuelSessionState | undefined,
+    action: Parameters<typeof duelSessionReducer>[1],
+) => duelSessionReducer(state, action);
+
+const beginSearch = (state: DuelSessionState | undefined, context = rankedContext) => {
+    const action = beginDuelSearch(context);
+    return { action, state: reduce(state, action) };
+};
+
+describe("duel session state machine", () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it.each([
+        ["Ranked", rankedContext],
+        [
+            "Friendly",
+            {
+                nickname: "friend",
+                configurationId: 12,
+                invitationType: "Friendly",
+                tournamentId: null,
+            } satisfies DuelSearchContext,
+        ],
+        [
+            "Group",
+            {
+                nickname: "member",
+                configurationId: 13,
+                invitationType: "Group",
+                tournamentId: null,
+            } satisfies DuelSearchContext,
+        ],
+        [
+            "Tournament",
+            {
+                nickname: "rival",
+                configurationId: 14,
+                invitationType: "Tournament",
+                tournamentId: 15,
+            } satisfies DuelSearchContext,
+        ],
+    ])("uses the same monotonic transitions for %s sessions", (_name, context) => {
+        const started = beginSearch(undefined, context);
+        const generation = started.action.payload.generation;
+        let state = reduce(
+            started.state,
+            confirmDuelStarted({ duelId: 101, expectedGeneration: generation, eventId: "start" }),
+        );
+
+        state = reduce(state, confirmDuelSearch({ generation }));
+
+        expect(state.phase).toBe("active");
+        expect(state.activeDuelId).toBe(101);
+        expect(state.pendingOperation).toBeNull();
+    });
+
+    it("is order-independent when the HTTP success and DuelStarted race", () => {
+        vi.useFakeTimers();
+        const started = beginSearch(undefined);
+        const generation = started.action.payload.generation;
+        let state = started.state;
+
+        setTimeout(() => {
+            state = reduce(state, confirmDuelSearch({ generation }));
+        }, 20);
+        setTimeout(() => {
+            state = reduce(
+                state,
+                confirmDuelStarted({
+                    duelId: 42,
+                    expectedGeneration: generation,
+                    eventId: "event-42",
+                    revision: 42,
+                }),
+            );
+        }, 10);
+
+        vi.advanceTimersByTime(10);
+        expect(state.phase).toBe("active");
+        vi.advanceTimersByTime(10);
+        expect(state.phase).toBe("active");
+        expect(state.activeDuelId).toBe(42);
+    });
+
+    it("does not let a late HTTP failure erase an active duel", () => {
+        const started = beginSearch(undefined);
+        const generation = started.action.payload.generation;
+        let state = reduce(
+            started.state,
+            confirmDuelStarted({ duelId: 7, expectedGeneration: generation }),
+        );
+
+        state = reduce(state, failDuelSearch({ generation }));
+
+        expect(state.phase).toBe("active");
+        expect(state.activeDuelId).toBe(7);
+    });
+
+    it("ignores responses and events from an older generation", () => {
+        const first = beginSearch(undefined);
+        const second = beginSearch(first.state, {
+            ...rankedContext,
+            nickname: "new-opponent",
+            invitationType: "Friendly",
+        });
+        const oldGeneration = first.action.payload.generation;
+        let state = reduce(first.state, second.action);
+
+        state = reduce(
+            state,
+            confirmDuelStarted({ duelId: 1, expectedGeneration: oldGeneration, eventId: "old" }),
+        );
+        state = reduce(state, confirmDuelSearch({ generation: oldGeneration }));
+        state = reduce(
+            state,
+            applyDuelSearchCanceled({
+                expectedGeneration: oldGeneration,
+                eventId: "old-cancel",
+            }),
+        );
+
+        expect(state.phase).toBe("searching");
+        expect(state.searchNickname).toBe("new-opponent");
+        expect(state.generation).toBe(second.action.payload.generation);
+    });
+
+    it("keeps an active duel when cancel loses the cancel-vs-start race", () => {
+        const started = beginSearch(undefined);
+        const cancelAction = beginDuelSearchCancellation();
+        let state = reduce(started.state, cancelAction);
+        const cancelGeneration = cancelAction.payload.generation;
+
+        state = reduce(
+            state,
+            confirmDuelStarted({ duelId: 9, expectedGeneration: cancelGeneration }),
+        );
+        state = reduce(state, confirmDuelSearchCancellation({ generation: cancelGeneration }));
+
+        expect(state.phase).toBe("active");
+        expect(state.activeDuelId).toBe(9);
+    });
+
+    it("ignores duplicate and out-of-order realtime events", () => {
+        const started = beginSearch(undefined);
+        const generation = started.action.payload.generation;
+        let state = reduce(
+            started.state,
+            confirmDuelStarted({
+                duelId: 25,
+                expectedGeneration: generation,
+                eventId: "event-25",
+                revision: 25,
+            }),
+        );
+
+        state = reduce(
+            state,
+            markDuelFinished({
+                duelId: 25,
+                expectedGeneration: generation,
+                eventId: "event-25",
+                revision: 25,
+            }),
+        );
+        state = reduce(
+            state,
+            markDuelFinished({
+                duelId: 25,
+                expectedGeneration: generation,
+                eventId: "event-24",
+                revision: 24,
+            }),
+        );
+
+        expect(state.phase).toBe("active");
+    });
+
+    it("retains the finished duel until its result data has loaded", () => {
+        const started = beginSearch(undefined);
+        const generation = started.action.payload.generation;
+        let state = reduce(
+            started.state,
+            confirmDuelStarted({ duelId: 31, expectedGeneration: generation }),
+        );
+        state = reduce(
+            state,
+            markDuelFinished({ duelId: 31, expectedGeneration: generation, eventId: "finish" }),
+        );
+        state = reduce(
+            state,
+            confirmDuelStarted({
+                duelId: 31,
+                expectedGeneration: generation,
+                eventId: "late-start",
+            }),
+        );
+
+        expect(state.phase).toBe("finished");
+        expect(state.activeDuelId).toBe(31);
+
+        state = reduce(state, completeFinishedDuel({ duelId: 31, generation }));
+        expect(state.phase).toBe("idle");
+        expect(state.activeDuelId).toBeNull();
+    });
+
+    it.each([
+        ["idle", null, null],
+        ["searching", null, null],
+        ["active", null, null],
+        ["idle", 18, 18],
+        ["searching", 18, 18],
+        ["active", 18, 18],
+    ] as const)(
+        "normalizes persisted %s/%s from the server duel id",
+        (persistedPhase, persistedDuelId, serverDuelId) => {
+            const persisted = {
+                ...reduce(undefined, { type: "test/init" }),
+                phase: persistedPhase,
+                activeDuelId: persistedDuelId,
+            } satisfies DuelSessionState;
+            const restoreAction = beginDuelSessionRestore();
+            let state = reduce(persisted, restoreAction);
+
+            state = reduce(
+                state,
+                reconcileDuelSessionSucceeded({
+                    generation: restoreAction.payload.generation,
+                    duelId: serverDuelId,
+                }),
+            );
+
+            expect(state.phase).toBe(serverDuelId ? "active" : "idle");
+            expect(state.activeDuelId).toBe(serverDuelId);
+        },
+    );
+
+    it("keeps the interrupted phase explicit until server reconciliation", () => {
+        const started = beginSearch(undefined);
+        let state = reduce(started.state, markDuelSessionInterrupted());
+
+        expect(state.phase).toBe("interrupted");
+        expect(state.interruptedPhase).toBe("searching");
+
+        const restoreAction = beginDuelSessionRestore();
+        state = reduce(state, restoreAction);
+        state = reduce(
+            state,
+            reconcileDuelSessionSucceeded({
+                generation: restoreAction.payload.generation,
+                duelId: 88,
+            }),
+        );
+
+        expect(state.phase).toBe("active");
+        expect(state.activeDuelId).toBe(88);
+    });
+});

--- a/src/features/duel-session/model/duelSessionSlice.ts
+++ b/src/features/duel-session/model/duelSessionSlice.ts
@@ -1,20 +1,37 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { createSlice, nanoid, type PayloadAction } from "@reduxjs/toolkit";
 
 import { duelApiSlice, type DuelTaskRef } from "entities/duel";
 import type { PendingDuelType } from "entities/duel-invitation/model/types";
-import { DuelSessionState, DuelSessionPhase } from "./types";
-import { restoreDuelSession } from "./thunks";
 
-const isNotFoundError = (error: unknown) =>
-    typeof error === "object" &&
-    error !== null &&
-    "status" in error &&
-    (error as { status?: number }).status === 404;
+import type {
+    DuelSearchContext,
+    DuelSessionEventMetadata,
+    DuelSessionPhase,
+    DuelSessionState,
+} from "./types";
 
-const initialState: DuelSessionState = {
+const MAX_RECENT_EVENT_IDS = 32;
+
+export const DUEL_SESSION_TRANSITIONS: Readonly<
+    Record<DuelSessionPhase, readonly DuelSessionPhase[]>
+> = {
+    idle: ["configuring", "searching", "active", "interrupted"],
+    configuring: ["idle", "searching", "active", "interrupted"],
+    searching: ["configuring", "idle", "active", "interrupted"],
+    active: ["finished", "interrupted"],
+    finished: ["idle", "active", "interrupted"],
+    interrupted: ["configuring", "idle", "active", "finished"],
+};
+
+export const initialDuelSessionState: DuelSessionState = {
     activeDuelId: null,
     phase: "idle",
+    generation: null,
+    pendingOperation: null,
+    interruptedPhase: null,
     lastEventId: null,
+    lastServerRevision: null,
+    recentEventIds: [],
     searchNickname: null,
     searchConfigurationId: null,
     searchInvitationType: null,
@@ -25,6 +42,55 @@ const initialState: DuelSessionState = {
     sessionInterrupted: false,
     lastTasksByDuelId: {},
     openedTaskKeys: [],
+};
+
+const clearSearchContext = (state: DuelSessionState) => {
+    state.searchNickname = null;
+    state.searchConfigurationId = null;
+    state.searchInvitationType = null;
+    state.searchTournamentId = null;
+};
+
+const resetToIdle = (state: DuelSessionState) => {
+    state.activeDuelId = null;
+    state.phase = "idle";
+    state.pendingOperation = null;
+    state.interruptedPhase = null;
+    state.sessionInterrupted = false;
+    state.duelStatusChanged = false;
+    state.lastTasksByDuelId = {};
+    state.openedTaskKeys = [];
+    clearSearchContext(state);
+};
+
+const canApplyEvent = (state: DuelSessionState, metadata: DuelSessionEventMetadata) => {
+    if (metadata.generation && metadata.generation !== state.generation) {
+        return false;
+    }
+
+    if (
+        metadata.revision != null &&
+        state.lastServerRevision != null &&
+        metadata.revision <= state.lastServerRevision
+    ) {
+        return false;
+    }
+
+    return !metadata.eventId || !state.recentEventIds.includes(metadata.eventId);
+};
+
+const recordEvent = (state: DuelSessionState, metadata: DuelSessionEventMetadata) => {
+    if (metadata.revision != null) {
+        state.lastServerRevision = metadata.revision;
+    }
+
+    if (!metadata.eventId) return;
+
+    state.lastEventId = metadata.eventId;
+    state.recentEventIds.push(metadata.eventId);
+    if (state.recentEventIds.length > MAX_RECENT_EVENT_IDS) {
+        state.recentEventIds.splice(0, state.recentEventIds.length - MAX_RECENT_EVENT_IDS);
+    }
 };
 
 const buildTaskSnapshot = (tasks?: Record<string, DuelTaskRef> | null) => {
@@ -54,18 +120,196 @@ const getOpenedTaskKeys = (
 
 const duelSessionSlice = createSlice({
     name: "duelSession",
-    initialState,
+    initialState: initialDuelSessionState,
     reducers: {
-        setPhase: (state, action: PayloadAction<DuelSessionPhase>) => {
-            state.phase = action.payload;
-            if (action.payload === "idle") {
+        beginDuelConfiguration: {
+            reducer: (state, action: PayloadAction<{ generation: string }>) => {
+                if (state.phase !== "idle" && state.phase !== "configuring") return;
+
+                state.generation = action.payload.generation;
+                state.phase = "configuring";
+                state.pendingOperation = null;
+                state.duelCanceled = false;
+                state.duelCanceledOpponentNickname = null;
+            },
+            prepare: () => ({ payload: { generation: nanoid() } }),
+        },
+        finishDuelConfiguration: (state) => {
+            if (state.phase !== "configuring" || state.pendingOperation) return;
+            resetToIdle(state);
+        },
+        beginDuelSearch: {
+            reducer: (state, action: PayloadAction<DuelSearchContext & { generation: string }>) => {
+                const { generation, nickname, configurationId, invitationType, tournamentId } =
+                    action.payload;
+
+                state.generation = generation;
+                state.phase = "searching";
+                state.pendingOperation = "start";
+                state.interruptedPhase = null;
                 state.activeDuelId = null;
-                state.searchNickname = null;
-                state.searchConfigurationId = null;
-                state.searchInvitationType = null;
-                state.searchTournamentId = null;
+                state.searchNickname = nickname;
+                state.searchConfigurationId = configurationId;
+                state.searchInvitationType = invitationType;
+                state.searchTournamentId = tournamentId;
+                state.duelCanceled = false;
+                state.duelCanceledOpponentNickname = null;
+                state.duelStatusChanged = false;
+                state.sessionInterrupted = false;
                 state.lastTasksByDuelId = {};
+                state.openedTaskKeys = [];
+            },
+            prepare: (context: DuelSearchContext) => ({
+                payload: { ...context, generation: nanoid() },
+            }),
+        },
+        confirmDuelSearch: (state, action: PayloadAction<{ generation: string }>) => {
+            if (action.payload.generation !== state.generation) return;
+            if (state.pendingOperation === "start") {
+                state.pendingOperation = null;
             }
+        },
+        failDuelSearch: (state, action: PayloadAction<{ generation: string }>) => {
+            if (action.payload.generation !== state.generation) return;
+            if (state.phase === "active" || state.phase === "finished") return;
+            resetToIdle(state);
+        },
+        beginDuelSearchCancellation: {
+            reducer: (state, action: PayloadAction<{ generation: string }>) => {
+                if (state.phase !== "searching") return;
+
+                state.generation = action.payload.generation;
+                state.phase = "configuring";
+                state.pendingOperation = "cancel";
+            },
+            prepare: () => ({ payload: { generation: nanoid() } }),
+        },
+        confirmDuelSearchCancellation: (state, action: PayloadAction<{ generation: string }>) => {
+            if (action.payload.generation !== state.generation) return;
+            if (state.phase === "active" || state.phase === "finished") return;
+            resetToIdle(state);
+        },
+        failDuelSearchCancellation: (state, action: PayloadAction<{ generation: string }>) => {
+            if (action.payload.generation !== state.generation) return;
+            if (state.phase === "active" || state.phase === "finished") return;
+
+            state.phase = "searching";
+            state.pendingOperation = null;
+        },
+        beginDuelSessionRestore: {
+            reducer: (state, action: PayloadAction<{ generation: string }>) => {
+                state.generation = action.payload.generation;
+                state.phase = "configuring";
+                state.pendingOperation = "restore";
+                state.interruptedPhase = null;
+                state.sessionInterrupted = false;
+            },
+            prepare: () => ({ payload: { generation: nanoid() } }),
+        },
+        reconcileDuelSessionSucceeded: (
+            state,
+            action: PayloadAction<{ generation: string; duelId: number | null }>,
+        ) => {
+            if (action.payload.generation !== state.generation) return;
+
+            if (action.payload.duelId == null) {
+                resetToIdle(state);
+                return;
+            }
+
+            if (state.activeDuelId !== action.payload.duelId) {
+                state.lastTasksByDuelId = {};
+                state.openedTaskKeys = [];
+            }
+            state.activeDuelId = action.payload.duelId;
+            state.phase = "active";
+            state.pendingOperation = null;
+            state.interruptedPhase = null;
+            state.sessionInterrupted = false;
+            state.duelStatusChanged = false;
+            clearSearchContext(state);
+        },
+        reconcileDuelSessionFailed: (state, action: PayloadAction<{ generation: string }>) => {
+            if (action.payload.generation !== state.generation) return;
+
+            state.interruptedPhase = state.activeDuelId ? "active" : "idle";
+            state.phase = "interrupted";
+            state.pendingOperation = null;
+            state.sessionInterrupted = true;
+        },
+        confirmDuelStarted: (
+            state,
+            action: PayloadAction<
+                { duelId: number; expectedGeneration: string | null } & DuelSessionEventMetadata
+            >,
+        ) => {
+            const { duelId, expectedGeneration, ...metadata } = action.payload;
+            if (expectedGeneration !== state.generation || !canApplyEvent(state, metadata)) return;
+            if (state.phase === "finished" && state.activeDuelId === duelId) return;
+
+            recordEvent(state, metadata);
+            if (state.activeDuelId !== duelId) {
+                state.lastTasksByDuelId = {};
+                state.openedTaskKeys = [];
+            }
+            state.activeDuelId = duelId;
+            state.phase = "active";
+            state.pendingOperation = null;
+            state.interruptedPhase = null;
+            state.sessionInterrupted = false;
+            state.duelStatusChanged = false;
+            clearSearchContext(state);
+        },
+        markDuelFinished: (
+            state,
+            action: PayloadAction<
+                { duelId: number; expectedGeneration: string | null } & DuelSessionEventMetadata
+            >,
+        ) => {
+            const { duelId, expectedGeneration, ...metadata } = action.payload;
+            if (expectedGeneration !== state.generation || !canApplyEvent(state, metadata)) return;
+            if (state.activeDuelId !== duelId) return;
+            if (state.phase !== "active") return;
+
+            recordEvent(state, metadata);
+            state.phase = "finished";
+            state.pendingOperation = null;
+            state.interruptedPhase = null;
+            state.sessionInterrupted = false;
+        },
+        completeFinishedDuel: (
+            state,
+            action: PayloadAction<{ duelId: number; generation: string | null }>,
+        ) => {
+            if (action.payload.generation !== state.generation) return;
+            if (state.phase !== "finished" || state.activeDuelId !== action.payload.duelId) return;
+            resetToIdle(state);
+        },
+        applyDuelSearchCanceled: (
+            state,
+            action: PayloadAction<{ expectedGeneration: string | null } & DuelSessionEventMetadata>,
+        ) => {
+            const { expectedGeneration, ...metadata } = action.payload;
+            if (expectedGeneration !== state.generation || !canApplyEvent(state, metadata)) return;
+            if (
+                state.phase !== "searching" &&
+                !(state.phase === "configuring" && state.pendingOperation === "start")
+            ) {
+                return;
+            }
+
+            recordEvent(state, metadata);
+            resetToIdle(state);
+        },
+        markDuelSessionInterrupted: (state) => {
+            if (state.phase !== "interrupted") {
+                state.interruptedPhase = state.phase;
+                state.phase = "interrupted";
+            }
+            state.sessionInterrupted = true;
+        },
+        dismissDuelSessionInterrupted: (state) => {
+            state.sessionInterrupted = false;
         },
         setDuelCanceled: (state, action: PayloadAction<boolean>) => {
             state.duelCanceled = action.payload;
@@ -82,31 +326,6 @@ const duelSessionSlice = createSlice({
         setOpenedTaskKeys: (state, action: PayloadAction<string[]>) => {
             state.openedTaskKeys = action.payload;
         },
-        setSessionInterrupted: (state, action: PayloadAction<boolean>) => {
-            state.sessionInterrupted = action.payload;
-        },
-        setActiveDuelId: (state, action: PayloadAction<number | null>) => {
-            if (state.activeDuelId !== action.payload) {
-                state.lastTasksByDuelId = {};
-                state.openedTaskKeys = [];
-            }
-            state.activeDuelId = action.payload;
-            if (action.payload) {
-                if (state.phase === "searching" || state.phase === "idle") {
-                    state.phase = "active";
-                }
-                state.searchNickname = null;
-                state.searchConfigurationId = null;
-                state.searchInvitationType = null;
-                state.searchTournamentId = null;
-                state.duelStatusChanged = false;
-                state.openedTaskKeys = [];
-            } else {
-                state.lastEventId = null;
-                state.duelStatusChanged = false;
-                state.openedTaskKeys = [];
-            }
-        },
         setLastEventId: (state, action: PayloadAction<string | null>) => {
             state.lastEventId = action.payload;
         },
@@ -122,46 +341,15 @@ const duelSessionSlice = createSlice({
         setSearchTournamentId: (state, action: PayloadAction<number | null>) => {
             state.searchTournamentId = action.payload;
         },
-        resetDuelSession: (state) => {
-            state.activeDuelId = null;
-            state.phase = "idle";
-            state.lastEventId = null;
-            state.searchNickname = null;
-            state.searchConfigurationId = null;
-            state.searchInvitationType = null;
-            state.searchTournamentId = null;
-            state.duelCanceled = false;
-            state.duelCanceledOpponentNickname = null;
-            state.duelStatusChanged = false;
-            state.sessionInterrupted = false;
-            state.lastTasksByDuelId = {};
-            state.openedTaskKeys = [];
+        resetDuelSession: {
+            reducer: (state, action: PayloadAction<{ generation: string }>) => {
+                const generation = action.payload.generation;
+                Object.assign(state, initialDuelSessionState, { generation });
+            },
+            prepare: () => ({ payload: { generation: nanoid() } }),
         },
     },
     extraReducers: (builder) => {
-        builder.addMatcher(
-            duelApiSlice.endpoints.getActiveDuel.matchFulfilled,
-            (state, { payload }) => {
-                state.activeDuelId = payload.id;
-                restoreDuelSession(state.activeDuelId);
-            },
-        );
-        builder.addMatcher(
-            duelApiSlice.endpoints.getActiveDuel.matchRejected,
-            (state, { payload }) => {
-                if (!isNotFoundError(payload)) return;
-
-                if (state.phase === "active") {
-                    state.activeDuelId = null;
-                    state.phase = "idle";
-                    state.lastEventId = null;
-                    state.duelCanceled = false;
-                    state.duelCanceledOpponentNickname = null;
-                    state.duelStatusChanged = false;
-                    state.openedTaskKeys = [];
-                }
-            },
-        );
         builder.addMatcher(duelApiSlice.endpoints.getDuel.matchFulfilled, (state, { payload }) => {
             const duelId = payload.id;
             const hasPreviousSnapshot = Object.prototype.hasOwnProperty.call(
@@ -185,18 +373,33 @@ const duelSessionSlice = createSlice({
 });
 
 export const {
-    setPhase,
+    applyDuelSearchCanceled,
+    beginDuelConfiguration,
+    beginDuelSearch,
+    beginDuelSearchCancellation,
+    beginDuelSessionRestore,
+    completeFinishedDuel,
+    confirmDuelSearch,
+    confirmDuelSearchCancellation,
+    confirmDuelStarted,
+    dismissDuelSessionInterrupted,
+    failDuelSearch,
+    failDuelSearchCancellation,
+    finishDuelConfiguration,
+    markDuelFinished,
+    markDuelSessionInterrupted,
+    reconcileDuelSessionFailed,
+    reconcileDuelSessionSucceeded,
+    resetDuelSession,
     setDuelCanceled,
     setDuelCanceledOpponentNickname,
     setDuelStatusChanged,
-    setOpenedTaskKeys,
-    setActiveDuelId,
     setLastEventId,
-    setSearchNickname,
+    setOpenedTaskKeys,
     setSearchConfigurationId,
     setSearchInvitationType,
+    setSearchNickname,
     setSearchTournamentId,
-    setSessionInterrupted,
-    resetDuelSession,
 } = duelSessionSlice.actions;
+
 export default duelSessionSlice.reducer;

--- a/src/features/duel-session/model/thunks.ts
+++ b/src/features/duel-session/model/thunks.ts
@@ -1,21 +1,103 @@
 import { createAsyncThunk } from "@reduxjs/toolkit";
-import { duelApiSlice } from "entities/duel";
-import { resetDuelSession, setActiveDuelId } from "./duelSessionSlice";
 
-export const restoreDuelSession = createAsyncThunk<void, number, { dispatch: AppDispatch }>(
-    "duelSession/restore",
-    async (duelId, { dispatch }) => {
-        try {
-            const result = await dispatch(duelApiSlice.endpoints.getDuel.initiate(duelId));
-            const duel = result.data;
+import { duelApiSlice, getActiveDuelId } from "entities/duel";
 
-            if (duel?.status === "InProgress") {
-                dispatch(setActiveDuelId(duel.id));
-            } else {
-                dispatch(resetDuelSession());
-            }
-        } catch {
-            dispatch(resetDuelSession());
+import {
+    beginDuelSessionRestore,
+    confirmDuelStarted,
+    reconcileDuelSessionFailed,
+    reconcileDuelSessionSucceeded,
+} from "./duelSessionSlice";
+import type { DuelSessionEventMetadata } from "./types";
+
+const isNotFoundError = (error: unknown) =>
+    typeof error === "object" &&
+    error !== null &&
+    "status" in error &&
+    (error as { status?: number }).status === 404;
+
+const requestActiveDuelId = async (dispatch: AppDispatch) => {
+    try {
+        const activeDuel = await dispatch(
+            duelApiSlice.endpoints.getActiveDuel.initiate(undefined, {
+                forceRefetch: true,
+                subscribe: false,
+            }),
+        ).unwrap();
+        return getActiveDuelId(activeDuel);
+    } catch (error) {
+        if (isNotFoundError(error)) return null;
+        throw error;
+    }
+};
+
+const requestInProgressDuelId = async (dispatch: AppDispatch, duelId: number) => {
+    try {
+        const duel = await dispatch(
+            duelApiSlice.endpoints.getDuel.initiate(duelId, {
+                forceRefetch: true,
+                subscribe: false,
+            }),
+        ).unwrap();
+        return duel.status === "InProgress" ? duel.id : null;
+    } catch (error) {
+        if (isNotFoundError(error)) return null;
+        throw error;
+    }
+};
+
+export const reconcileDuelSession = createAsyncThunk<
+    void,
+    void,
+    { dispatch: AppDispatch; state: RootState }
+>("duelSession/reconcile", async (_, { dispatch, getState }) => {
+    const previousDuelId = getState().duelSession.activeDuelId;
+    const { generation } = dispatch(beginDuelSessionRestore()).payload;
+
+    try {
+        const activeDuelId = await requestActiveDuelId(dispatch);
+        const inProgressDuelId = activeDuelId
+            ? await requestInProgressDuelId(dispatch, activeDuelId)
+            : null;
+
+        if (!activeDuelId && previousDuelId) {
+            // Load a duel that finished while the client was offline before clearing its context.
+            await requestInProgressDuelId(dispatch, previousDuelId);
         }
-    },
-);
+
+        dispatch(
+            reconcileDuelSessionSucceeded({
+                generation,
+                duelId: inProgressDuelId,
+            }),
+        );
+    } catch {
+        dispatch(reconcileDuelSessionFailed({ generation }));
+    }
+});
+
+export const confirmDuelStartedFromServer = createAsyncThunk<
+    void,
+    { duelId: number; metadata: DuelSessionEventMetadata },
+    { dispatch: AppDispatch; state: RootState }
+>("duelSession/confirmStartedFromServer", async ({ duelId, metadata }, { dispatch, getState }) => {
+    const expectedGeneration = getState().duelSession.generation;
+
+    try {
+        const activeDuelId = await requestActiveDuelId(dispatch);
+        if (activeDuelId !== duelId) return;
+
+        const inProgressDuelId = await requestInProgressDuelId(dispatch, duelId);
+        if (inProgressDuelId !== duelId) return;
+
+        dispatch(
+            confirmDuelStarted({
+                duelId,
+                expectedGeneration,
+                ...metadata,
+            }),
+        );
+    } catch {
+        // A realtime start is only a hint. Keep the current state when the server cannot confirm it.
+    }
+});

--- a/src/features/duel-session/model/types.ts
+++ b/src/features/duel-session/model/types.ts
@@ -4,10 +4,32 @@ export interface DuelMessage {
     duel_id: number;
 }
 
+export interface DuelSearchContext {
+    nickname: string | null;
+    configurationId: number | null;
+    invitationType: PendingDuelType | null;
+    tournamentId: number | null;
+}
+
+export interface DuelSessionEventMetadata {
+    eventId?: string | null;
+    generation?: string | null;
+    revision?: number | null;
+}
+
+export type DuelSessionOperation = "start" | "cancel" | "restore" | null;
+
+export type ResumableDuelSessionPhase = Exclude<DuelSessionPhase, "interrupted">;
+
 export interface DuelSessionState {
     activeDuelId: number | null;
     phase: DuelSessionPhase;
+    generation: string | null;
+    pendingOperation: DuelSessionOperation;
+    interruptedPhase: ResumableDuelSessionPhase | null;
     lastEventId: string | null;
+    lastServerRevision: number | null;
+    recentEventIds: string[];
     searchNickname: string | null;
     searchConfigurationId: number | null;
     searchInvitationType: PendingDuelType | null;
@@ -20,4 +42,10 @@ export interface DuelSessionState {
     openedTaskKeys: string[];
 }
 
-export type DuelSessionPhase = "idle" | "searching" | "active";
+export type DuelSessionPhase =
+    | "idle"
+    | "configuring"
+    | "searching"
+    | "active"
+    | "finished"
+    | "interrupted";

--- a/src/features/duel-session/ui/DuelSessionButton/DuelSessionButton.tsx
+++ b/src/features/duel-session/ui/DuelSessionButton/DuelSessionButton.tsx
@@ -3,11 +3,12 @@ import {
     useStartDuelSearchMutation,
 } from "features/duel-session/api/duelSessionApi";
 import {
-    setPhase,
-    setSearchConfigurationId,
-    setSearchInvitationType,
-    setSearchNickname,
-    setSearchTournamentId,
+    beginDuelSearch,
+    beginDuelSearchCancellation,
+    confirmDuelSearch,
+    confirmDuelSearchCancellation,
+    failDuelSearch,
+    failDuelSearchCancellation,
 } from "features/duel-session/model/duelSessionSlice";
 import { selectDuelSession } from "features/duel-session/model/selectors";
 import { DuelSessionPhase } from "features/duel-session/model/types";
@@ -21,7 +22,7 @@ export const DuelSessionButton = () => {
 
     const dispatch = useAppDispatch();
 
-    const { phase, activeDuelId } = useAppSelector(selectDuelSession);
+    const { phase, activeDuelId, pendingOperation } = useAppSelector(selectDuelSession);
     const prevPhaseRef = useRef<DuelSessionPhase>(phase);
     const [startDuelSearch] = useStartDuelSearchMutation();
     const [cancelDuelSearch] = useCancelDuelSearchMutation();
@@ -36,24 +37,31 @@ export const DuelSessionButton = () => {
 
     const handleClick = async () => {
         if (phase === "idle") {
-            dispatch(setSearchNickname(null));
-            dispatch(setSearchConfigurationId(null));
-            dispatch(setSearchInvitationType(null));
-            dispatch(setSearchTournamentId(null));
+            const { generation } = dispatch(
+                beginDuelSearch({
+                    nickname: null,
+                    configurationId: null,
+                    invitationType: "Ranked",
+                    tournamentId: null,
+                }),
+            ).payload;
 
             try {
                 await startDuelSearch().unwrap();
             } catch {
+                dispatch(failDuelSearch({ generation }));
                 return;
             }
-            dispatch(setPhase("searching"));
+            dispatch(confirmDuelSearch({ generation }));
         } else if (phase === "searching") {
+            const { generation } = dispatch(beginDuelSearchCancellation()).payload;
             try {
                 await cancelDuelSearch().unwrap();
             } catch {
+                dispatch(failDuelSearchCancellation({ generation }));
                 return;
             }
-            dispatch(setPhase("idle"));
+            dispatch(confirmDuelSearchCancellation({ generation }));
         } else if (phase === "active" && activeDuelId) {
             navigate("/duel/" + activeDuelId);
         }
@@ -63,12 +71,28 @@ export const DuelSessionButton = () => {
         if (phase === "idle") {
             return "Начать поиск";
         } else if (phase === "searching") {
-            return "Отменить";
+            return pendingOperation === "start" ? "Запуск..." : "Отменить";
         } else if (phase === "active") {
             return "Перейти к дуэли";
+        } else if (phase === "finished") {
+            return "Загрузка результата...";
+        } else if (phase === "interrupted") {
+            return "Соединение прервано";
+        } else if (phase === "configuring" && pendingOperation === "cancel") {
+            return "Отмена...";
         }
         return "Начать поиск";
     };
 
-    return <Button onClick={handleClick}>{duelButtonText()}</Button>;
+    const disabled =
+        phase === "finished" ||
+        phase === "interrupted" ||
+        (phase === "searching" && pendingOperation === "start") ||
+        (phase === "configuring" && pendingOperation === "cancel");
+
+    return (
+        <Button onClick={handleClick} disabled={disabled}>
+            {duelButtonText()}
+        </Button>
+    );
 };

--- a/src/features/duel-session/ui/DuelSessionManager/DuelSessionManager.tsx
+++ b/src/features/duel-session/ui/DuelSessionManager/DuelSessionManager.tsx
@@ -2,13 +2,12 @@
 import { duelSessionApiSlice } from "features/duel-session/api/duelSessionApi";
 import { selectDuelSession } from "features/duel-session/model/selectors";
 import {
+    dismissDuelSessionInterrupted,
     resetDuelSession,
-    setPhase,
-    setSessionInterrupted,
 } from "features/duel-session/model/duelSessionSlice";
+import { reconcileDuelSession } from "features/duel-session/model/thunks";
 import { useEffect, useRef, useState } from "react";
-import { useAppSelector, useAppDispatch } from "shared/lib/storeHooks";
-import { restoreDuelSession } from "features/duel-session/model/thunks";
+import { useAppDispatch, useAppSelector } from "shared/lib/storeHooks";
 import { Button, Modal } from "shared/ui";
 import styles from "./DuelSessionManager.module.scss";
 
@@ -16,23 +15,24 @@ export const DuelSessionManager = () => {
     const dispatch = useAppDispatch();
 
     const user = useAppSelector(selectCurrentUser);
-    const { phase, activeDuelId, sessionInterrupted } = useAppSelector(selectDuelSession);
+    const { sessionInterrupted } = useAppSelector(selectDuelSession);
     const [isReconnecting, setIsReconnecting] = useState(false);
 
     const subscriptionRef = useRef<{ unsubscribe: () => void } | null>(null);
-    const didHandleReloadRef = useRef(false);
+    const reconciledUserIdRef = useRef<number | null>(null);
 
     useEffect(() => {
-        // If user logged in and he has an active duel but phase is idle, try to restore session
-        if (user && activeDuelId && phase === "idle") {
-            dispatch(restoreDuelSession(activeDuelId));
-        }
-    }, [user, activeDuelId, phase, dispatch]);
+        if (!user || reconciledUserIdRef.current === user.id) return;
+
+        reconciledUserIdRef.current = user.id;
+        void dispatch(reconcileDuelSession());
+    }, [user, dispatch]);
 
     // Full cleanup on user logout
     useEffect(() => {
         if (user) return;
 
+        reconciledUserIdRef.current = null;
         dispatch(resetDuelSession());
         if (subscriptionRef.current) {
             subscriptionRef.current.unsubscribe();
@@ -54,21 +54,6 @@ export const DuelSessionManager = () => {
             );
         }
     }, [user, dispatch]);
-
-    useEffect(() => {
-        if (!user || didHandleReloadRef.current) return;
-
-        const navigationEntry = performance.getEntriesByType("navigation")[0] as
-            | PerformanceNavigationTiming
-            | undefined;
-        const navigationType = navigationEntry?.type ?? null;
-
-        if (navigationType === "reload" && phase === "searching" && !activeDuelId) {
-            dispatch(setPhase("idle"));
-        }
-
-        didHandleReloadRef.current = true;
-    }, [user, phase, activeDuelId, dispatch]);
 
     const handleReconnect = () => {
         if (!user) return;
@@ -103,7 +88,7 @@ export const DuelSessionManager = () => {
                     showCloseButton={false}
                     closeOnOverlay={false}
                     onClose={() => {
-                        dispatch(setSessionInterrupted(false));
+                        dispatch(dismissDuelSessionInterrupted());
                         setIsReconnecting(false);
                     }}
                 >

--- a/src/pages/group/ui/GroupPage/GroupPage.tsx
+++ b/src/pages/group/ui/GroupPage/GroupPage.tsx
@@ -23,11 +23,7 @@ import {
     type TournamentMatchmakingType,
     type TournamentStatus,
 } from "entities/tournament";
-import {
-    setPhase,
-    setSearchConfigurationId,
-    setSearchNickname,
-} from "features/duel-session/model/duelSessionSlice";
+import { beginDuelSearch, confirmDuelSearch, failDuelSearch } from "features/duel-session";
 import { AppRoutes } from "shared/config";
 import { useAppDispatch, useAppSelector } from "shared/lib/storeHooks";
 import EditIcon from "shared/assets/icons/edit.svg?react";
@@ -67,7 +63,8 @@ const tournamentMatchmakingOptions: Array<{
     {
         value: "GroupStage",
         title: "Group Stage",
-        description: "Каждый участник играет дуэль с каждым. Победа дает 3 очка, ничья - 1, поражение - 0.",
+        description:
+            "Каждый участник играет дуэль с каждым. Победа дает 3 очка, ничья - 1, поражение - 0.",
     },
 ];
 
@@ -670,6 +667,16 @@ const GroupPage = () => {
     ) => {
         if (!opponentNickname) return;
 
+        const { generation } = dispatch(
+            beginDuelSearch({
+                nickname: opponentNickname,
+                configurationId: configurationId ?? null,
+                invitationType: "Group",
+                tournamentId: null,
+            }),
+        ).payload;
+        sessionStorage.setItem("home.waitingForStart", JSON.stringify(true));
+
         try {
             await acceptGroupDuelInvitation({
                 group_id: groupId,
@@ -677,12 +684,11 @@ const GroupPage = () => {
                 configuration_id: configurationId ?? undefined,
             }).unwrap();
 
-            dispatch(setSearchNickname(opponentNickname));
-            dispatch(setSearchConfigurationId(configurationId ?? null));
-            dispatch(setPhase("searching"));
-            sessionStorage.setItem("home.waitingForStart", JSON.stringify(true));
+            dispatch(confirmDuelSearch({ generation }));
             navigate(AppRoutes.INDEX);
         } catch {
+            dispatch(failDuelSearch({ generation }));
+            sessionStorage.removeItem("home.waitingForStart");
             return;
         }
     };

--- a/src/pages/home/ui/HomePage.tsx
+++ b/src/pages/home/ui/HomePage.tsx
@@ -1,7 +1,6 @@
 ﻿import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 
-import { useGetActiveDuelQuery } from "entities/duel";
 import type { DuelConfiguration } from "entities/duel-configuration";
 import { useGetDuelConfigurationsQuery } from "entities/duel-configuration";
 import {
@@ -21,18 +20,20 @@ import { roleLabels } from "entities/group";
 import { selectCurrentUser } from "entities/user";
 import { DuelConfigurationManager, DuelConfigurationPicker } from "features/duel-configuration";
 import {
+    beginDuelConfiguration,
+    beginDuelSearch,
+    confirmDuelSearch,
     DuelSessionButton,
+    failDuelSearch,
+    finishDuelConfiguration,
     selectDuelSession,
-    useStartDuelSearchMutation,
-} from "features/duel-session";
-import {
     setDuelCanceled,
-    setPhase,
     setSearchConfigurationId,
     setSearchInvitationType,
     setSearchNickname,
     setSearchTournamentId,
-} from "features/duel-session/model/duelSessionSlice";
+    useStartDuelSearchMutation,
+} from "features/duel-session";
 import CrossIcon from "shared/assets/icons/cross.svg?react";
 import { useAppDispatch, useAppSelector } from "shared/lib/storeHooks";
 import { useSessionStorage } from "shared/lib/useSessionStorage";
@@ -86,6 +87,7 @@ const HomePage = () => {
         activeDuelId,
         duelCanceled,
         duelCanceledOpponentNickname,
+        pendingOperation,
         searchInvitationType,
     } = useAppSelector(selectDuelSession);
     const dispatch = useAppDispatch();
@@ -142,8 +144,6 @@ const HomePage = () => {
     const [denyGroupInvitation, { isLoading: isDenyingGroupInvitation }] =
         useDenyGroupInvitationMutation();
     const [startDuelSearch] = useStartDuelSearchMutation();
-    useGetActiveDuelQuery(undefined, { skip: !user });
-
     useEffect(() => {
         if (!user?.id) return;
         // Duel invitations are loaded via useGetDuelInvitationsQuery per type.
@@ -151,7 +151,7 @@ const HomePage = () => {
     }, [user?.id, loadGroupInvitations]);
 
     useEffect(() => {
-        if (phase === "idle") return;
+        if (phase === "idle" || phase === "configuring") return;
 
         setShowStartPanel(false);
         setShowConfigPicker(false);
@@ -225,6 +225,11 @@ const HomePage = () => {
     >("home.pendingGroupInvitationId", null);
 
     const handleStartPanelToggle = () => {
+        if (showStartPanel) {
+            dispatch(finishDuelConfiguration());
+        } else {
+            dispatch(beginDuelConfiguration());
+        }
         setShowStartPanel((prev) => !prev);
         if (showStartPanel) {
             setShowConfigPicker(false);
@@ -238,23 +243,29 @@ const HomePage = () => {
     };
 
     const handleStartPanelClose = () => {
+        dispatch(finishDuelConfiguration());
         setShowStartPanel(false);
         setSelectedConfigId(null);
     };
 
     const handleQuickSearch = async () => {
-        dispatch(setSearchNickname(null));
-        dispatch(setSearchConfigurationId(null));
-        dispatch(setSearchInvitationType(null));
-        dispatch(setSearchTournamentId(null));
+        const { generation } = dispatch(
+            beginDuelSearch({
+                nickname: null,
+                configurationId: null,
+                invitationType: "Ranked",
+                tournamentId: null,
+            }),
+        ).payload;
 
         try {
             await startDuelSearch().unwrap();
         } catch {
+            dispatch(failDuelSearch({ generation }));
             return;
         }
 
-        dispatch(setPhase("searching"));
+        dispatch(confirmDuelSearch({ generation }));
         setWaitingForStart(false);
         setShowStartPanel(false);
         setShowConfigPicker(false);
@@ -280,6 +291,7 @@ const HomePage = () => {
     };
 
     const handleConfigClose = () => {
+        dispatch(finishDuelConfiguration());
         setShowConfigPicker(false);
         setSelectedConfigId(null);
         dispatch(setSearchConfigurationId(null));
@@ -319,6 +331,7 @@ const HomePage = () => {
     };
 
     const handleFriendlyClose = () => {
+        dispatch(finishDuelConfiguration());
         setShowFriendlyForm(false);
         setFriendlyNickname("");
         setSelectedConfigId(null);
@@ -345,6 +358,14 @@ const HomePage = () => {
         }
 
         const configurationId = selectedDefaultConfig ? null : selectedConfigId;
+        const { generation } = dispatch(
+            beginDuelSearch({
+                nickname: trimmedNickname,
+                configurationId: configurationId ?? null,
+                invitationType: "Friendly",
+                tournamentId: null,
+            }),
+        ).payload;
 
         try {
             setInviteError(null);
@@ -353,6 +374,7 @@ const HomePage = () => {
                 configuration_id: configurationId ?? undefined,
             }).unwrap();
         } catch (error) {
+            dispatch(failDuelSearch({ generation }));
             if (
                 error &&
                 typeof error === "object" &&
@@ -369,11 +391,7 @@ const HomePage = () => {
             return;
         }
 
-        dispatch(setSearchNickname(trimmedNickname));
-        dispatch(setSearchConfigurationId(configurationId ?? null));
-        dispatch(setSearchInvitationType("Friendly"));
-        dispatch(setSearchTournamentId(null));
-        dispatch(setPhase("searching"));
+        dispatch(confirmDuelSearch({ generation }));
         setWaitingForStart(false);
         setShowStartPanel(false);
         setShowConfigPicker(false);
@@ -397,6 +415,16 @@ const HomePage = () => {
         if (invitationType === "Group" && !groupId) return;
         if (invitationType === "Tournament" && !tournamentId) return;
 
+        const { generation } = dispatch(
+            beginDuelSearch({
+                nickname,
+                configurationId: configurationId ?? null,
+                invitationType: invitationType ?? "Ranked",
+                tournamentId: tournamentId ?? null,
+            }),
+        ).payload;
+        setWaitingForStart(true);
+
         try {
             if (invitationType === "Group") {
                 await acceptGroupDuelInvitation({
@@ -415,15 +443,12 @@ const HomePage = () => {
                 }).unwrap();
             }
         } catch {
+            dispatch(failDuelSearch({ generation }));
+            setWaitingForStart(false);
             return;
         }
 
-        dispatch(setSearchNickname(nickname));
-        dispatch(setSearchConfigurationId(configurationId ?? null));
-        dispatch(setSearchInvitationType(invitationType ?? "Ranked"));
-        dispatch(setSearchTournamentId(tournamentId ?? null));
-        dispatch(setPhase("searching"));
-        setWaitingForStart(true);
+        dispatch(confirmDuelSearch({ generation }));
     };
 
     const handleInvitationDeny = async (nickname: string, configurationId?: number | null) => {
@@ -486,7 +511,11 @@ const HomePage = () => {
                         <IdleStateContent nickname={user?.nickname ?? "Аноним"} />
                     )}
 
-                    {phase === "searching" || phase === "active" ? (
+                    {phase === "searching" ||
+                    phase === "active" ||
+                    phase === "finished" ||
+                    phase === "interrupted" ||
+                    (phase === "configuring" && pendingOperation === "cancel") ? (
                         <div className={styles.duelAction}>
                             <DuelSessionButton />
                         </div>


### PR DESCRIPTION
## Summary

- replace ad-hoc duel session mutations with a generation-aware, monotonic state machine
- reconcile reconnect/reload state with the server and confirm realtime starts against the active duel
- reject stale HTTP completions, duplicate/out-of-order events, and cancel/start or finish/start races
- retain finished duel context until the result request succeeds
- support both the current full-duel active response and the planned nullable `{ duel_id }` contract
- cover all duel types, race permutations, stale generations, persisted states, and interruption recovery with 17 Vitest tests

## Root cause

HTTP responses, persisted Redux state, and WebSocket events could arrive in any order, but each path mutated the session independently. Late callbacks could therefore roll an active or finished duel back to searching/idle, and reconnect logic relied on UI-local heuristics.

## Verification

- `pnpm test` — passed (17 tests)
- `pnpm lint` — passed (7 existing warnings)
- `pnpm build` — passed
- `pnpm fsd:lint` — still reports the repository's existing 16 architecture errors and 17 warnings; this change adds no new category of violation

Closes #75