### PR TITLE
fix(ui): resolve responsive interaction traps

### DIFF
--- a/docs/processes/groups.md
+++ b/docs/processes/groups.md
@@ -32,6 +32,9 @@ Existing-group invitation behaves similarly. `/groups/:id` redirects to
 and shows modal/status handling for selected `403/404` errors. Roles are exactly
 `Creator`, `Manager`, `Member`; membership statuses include `Active`, `Pending`.
 Creators can edit non-creators; managers can edit members; self-edit is hidden.
+Pending memberships are labeled separately from active members, and an inviter
+with permission gets an explicit cancel-invitation action instead of an
+exclude-member action.
 
 ## Client state transitions
 

--- a/docs/processes/tournaments.md
+++ b/docs/processes/tournaments.md
@@ -27,9 +27,12 @@ strategies include `SingleEliminationBracket` and `GroupStage`.
 ## Current behavior
 
 Creation uses four component-state steps and posts participant nicknames plus
-configuration. Success invalidates the group tournament tag. Detail is cached by
-tournament ID; start invalidates both entity and group list. Start UI is visible
-for `New` to current Creator/Manager. A validated
+configuration. The participant step separates accepted group members from
+pending membership invitations; only accepted members with a nickname are
+selectable, while pending invitees remain visible with an unavailable status.
+Success invalidates the group tournament tag. Detail is cached by tournament ID;
+start invalidates both entity and group list. Start UI is visible for `New` to
+current Creator/Manager. A validated
 `TournamentDuelInvitation` invalidates duel-invitation and tournament
 projections. Acceptance invalidates tournament entity and invitations, then
 persists opponent/config/type/tournament ID, sets Home waiting, and awaits

--- a/src/app/layout/Layout.module.scss
+++ b/src/app/layout/Layout.module.scss
@@ -2,7 +2,7 @@
     height: 100%;
     display: grid;
     grid-template-areas: "header" "content";
-    grid-template-rows: 70px minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
 
     overflow: hidden;
 }
@@ -14,4 +14,5 @@
 
     overflow: auto;
     scrollbar-color: var(--card-secondary) transparent;
+    scroll-padding-top: 1em;
 }

--- a/src/app/styles/themes/index.scss
+++ b/src/app/styles/themes/index.scss
@@ -2,6 +2,17 @@
 @use "light";
 
 .app {
+    --font-family-sans: "Inter", sans-serif;
+    --font-size-xs: 0.75rem;
+    --font-size-sm: 0.875rem;
+    --font-size-md: 1rem;
+    --font-size-lg: 1.25rem;
+    --font-size-xl: 1.5rem;
+    --font-weight-regular: 400;
+    --font-weight-medium: 500;
+    --font-weight-semibold: 600;
+    --font-weight-bold: 700;
+
     --accent-primary: #6064cf;
     --accent-secondary: #9fa1e7;
 

--- a/src/entities/user/ui/UserCard/UserCard.module.scss
+++ b/src/entities/user/ui/UserCard/UserCard.module.scss
@@ -3,7 +3,11 @@
     align-items: center;
     justify-content: end;
     column-gap: 0.75em;
-    cursor: pointer;
+    min-width: 0;
+    padding: 0.25em;
+    border-radius: 0.6em;
+    color: inherit;
+    text-align: inherit;
 
     &.reversed {
         flex-direction: row-reverse;
@@ -15,6 +19,22 @@
     }
 }
 
+.interactive {
+    cursor: pointer;
+    transition:
+        background 0.15s ease,
+        box-shadow 0.15s ease;
+
+    &:hover {
+        background: color-mix(in srgb, var(--card-secondary) 65%, transparent);
+    }
+
+    &:focus-visible {
+        outline: 0.125em solid var(--accent-secondary);
+        outline-offset: 0.125em;
+    }
+}
+
 .userInfo {
     display: flex;
     flex-direction: column;
@@ -23,10 +43,12 @@
 }
 
 .nickname {
+    display: block;
     max-width: 10em;
 
-    overflow-x: hidden;
+    overflow: hidden;
     text-overflow: ellipsis;
+    white-space: nowrap;
 
     font-size: 1.25rem;
 }
@@ -60,4 +82,10 @@
     flex-shrink: 0;
 
     border-radius: 50%;
+}
+
+@media (max-width: 560px) {
+    .compactOnMobile .userInfo {
+        display: none;
+    }
 }

--- a/src/entities/user/ui/UserCard/UserCard.test.tsx
+++ b/src/entities/user/ui/UserCard/UserCard.test.tsx
@@ -1,0 +1,27 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { UserCard } from "./UserCard";
+
+vi.mock("shared/ui", () => ({
+    AnimatedNumber: ({ value }: { value: number }) => <span>{value}</span>,
+}));
+
+const user = {
+    id: 1,
+    nickname: "tourist",
+    rating: 1500,
+    created_at: "2026-07-24T00:00:00Z",
+};
+
+describe("UserCard", () => {
+    it("uses a button only when the card has an action", () => {
+        const staticMarkup = renderToStaticMarkup(<UserCard user={user} />);
+        const interactiveMarkup = renderToStaticMarkup(
+            <UserCard user={user} onClick={() => undefined} ariaLabel="Открыть профиль tourist" />,
+        );
+
+        expect(staticMarkup.startsWith("<span")).toBe(true);
+        expect(interactiveMarkup.startsWith("<button")).toBe(true);
+        expect(interactiveMarkup).toContain('aria-label="Открыть профиль tourist"');
+    });
+});

--- a/src/entities/user/ui/UserCard/UserCard.tsx
+++ b/src/entities/user/ui/UserCard/UserCard.tsx
@@ -12,15 +12,25 @@ interface Props {
     reversed?: boolean;
     ratingDelta?: number;
     onClick?: () => void;
+    compactOnMobile?: boolean;
+    ariaLabel?: string;
 }
 
-export const UserCard = ({ user, hideInfo, reversed, ratingDelta, onClick }: Props) => {
-    return (
-        <div className={clsx(styles.user, reversed && styles.reversed)} onClick={onClick}>
+export const UserCard = ({
+    user,
+    hideInfo,
+    reversed,
+    ratingDelta,
+    onClick,
+    compactOnMobile,
+    ariaLabel,
+}: Props) => {
+    const content = (
+        <>
             {!hideInfo && (
-                <div className={styles.userInfo}>
-                    <p className={styles.nickname}>{user.nickname}</p>
-                    <div className={styles.rating}>
+                <span className={styles.userInfo}>
+                    <span className={styles.nickname}>{user.nickname}</span>
+                    <span className={styles.rating}>
                         <CupIcon />
 
                         <AnimatedNumber
@@ -35,11 +45,28 @@ export const UserCard = ({ user, hideInfo, reversed, ratingDelta, onClick }: Pro
                                 ({ratingDelta > 0 ? `+${ratingDelta}` : ratingDelta})
                             </span>
                         )}
-                    </div>
-                </div>
+                    </span>
+                </span>
             )}
 
             <UserIcon className={styles.userIcon} />
-        </div>
+        </>
     );
+
+    const className = clsx(
+        styles.user,
+        reversed && styles.reversed,
+        compactOnMobile && styles.compactOnMobile,
+        onClick && styles.interactive,
+    );
+
+    if (onClick) {
+        return (
+            <button type="button" className={className} onClick={onClick} aria-label={ariaLabel}>
+                {content}
+            </button>
+        );
+    }
+
+    return <span className={className}>{content}</span>;
 };

--- a/src/features/duel-session/ui/DuelInfo/DuelInfo.tsx
+++ b/src/features/duel-session/ui/DuelInfo/DuelInfo.tsx
@@ -65,9 +65,10 @@ export const DuelInfo = ({ duelId }: Props) => {
     const delta = delta1 ?? 0;
     const changeText = delta > 0 ? `+${delta}` : delta;
 
-    const handleOnUserClick = (userId: number, nickname: string) =>
-        userId !== currentUser?.id &&
-        navigate(AppRoutes.PROFILE.replace(":userNickname", nickname));
+    const getProfileClickHandler = (userId: number, nickname: string) =>
+        userId === currentUser?.id
+            ? undefined
+            : () => navigate(AppRoutes.PROFILE.replace(":userNickname", nickname));
 
     return (
         <>
@@ -75,7 +76,8 @@ export const DuelInfo = ({ duelId }: Props) => {
                 <UserCard
                     user={user1}
                     ratingDelta={delta1}
-                    onClick={() => handleOnUserClick(user1.id, user1.nickname)}
+                    onClick={getProfileClickHandler(user1.id, user1.nickname)}
+                    ariaLabel={`Открыть профиль ${user1.nickname}`}
                 />
                 <div className={styles.duelContent}>
                     {duel.status === "InProgress" ? (
@@ -92,7 +94,8 @@ export const DuelInfo = ({ duelId }: Props) => {
                     user={user2}
                     reversed
                     ratingDelta={delta2}
-                    onClick={() => handleOnUserClick(user2.id, user2.nickname)}
+                    onClick={getProfileClickHandler(user2.id, user2.nickname)}
+                    ariaLabel={`Открыть профиль ${user2.nickname}`}
                 />
             </div>
             {showResultModal && duelResult !== null && (

--- a/src/pages/group/lib/tournamentParticipants.test.ts
+++ b/src/pages/group/lib/tournamentParticipants.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import type { GroupUser } from "entities/group";
+import { getTournamentParticipantGroups } from "./tournamentParticipants";
+
+const createMember = (
+    id: number,
+    status: GroupUser["status"],
+    nickname = `user-${id}`,
+): GroupUser => ({
+    user: { id, nickname, rating: 1500, created_at: "2026-07-24T00:00:00Z" },
+    role: "Member",
+    status,
+});
+
+describe("getTournamentParticipantGroups", () => {
+    it("keeps pending invitees visible but excludes them from tournament selection", () => {
+        const accepted = createMember(1, "Active");
+        const pending = createMember(2, "Pending");
+
+        const groups = getTournamentParticipantGroups([accepted, pending]);
+
+        expect(groups.accepted).toEqual([accepted]);
+        expect(groups.pending).toEqual([pending]);
+        expect(groups.selectable).toEqual([accepted]);
+    });
+
+    it("does not make an accepted member without a nickname selectable", () => {
+        const member = createMember(1, "Active", "");
+
+        const groups = getTournamentParticipantGroups([member]);
+
+        expect(groups.accepted).toEqual([member]);
+        expect(groups.selectable).toEqual([]);
+    });
+});

--- a/src/pages/group/lib/tournamentParticipants.ts
+++ b/src/pages/group/lib/tournamentParticipants.ts
@@ -1,0 +1,11 @@
+import type { GroupUser } from "entities/group";
+
+export const getTournamentParticipantGroups = (members: GroupUser[]) => {
+    const accepted = members.filter((member) => member.status === "Active");
+
+    return {
+        accepted,
+        pending: members.filter((member) => member.status === "Pending"),
+        selectable: accepted.filter((member) => Boolean(member.user.nickname)),
+    };
+};

--- a/src/pages/group/ui/GroupPage/GroupPage.module.scss
+++ b/src/pages/group/ui/GroupPage/GroupPage.module.scss
@@ -1,4 +1,6 @@
 .groupPage {
+    font-family: var(--font-family-sans);
+    font-size: var(--font-size-md);
     display: flex;
     justify-content: center;
     padding: 2em 1.5em 3em;
@@ -48,6 +50,7 @@
     flex-direction: column;
     gap: 0.85em;
     margin-top: -0.35em;
+    overflow-x: auto;
 }
 
 .duelsSection {
@@ -116,8 +119,8 @@
     border-radius: 999px;
     background: color-mix(in srgb, var(--card-secondary) 75%, transparent);
     color: var(--text-secondary);
-    font-size: 0.85rem;
-    font-weight: 600;
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
 }
 
 .duelPlayerCell {
@@ -206,13 +209,21 @@
     padding: 0.35em 0;
     color: var(--text-secondary);
     font: inherit;
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
     cursor: pointer;
     transition: color 0.15s ease;
 }
 
 .tabButton:hover {
     color: var(--text-primary);
+}
+
+.tabButton:focus-visible,
+.userLink:focus-visible,
+.inviterLink:focus-visible,
+.schemeCard:focus-visible {
+    outline: 0.125em solid var(--accent-secondary);
+    outline-offset: 0.125em;
 }
 
 .tabButtonActive {
@@ -246,7 +257,8 @@
 }
 
 .title {
-    font-size: 1.5rem;
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-weight-bold);
     margin-bottom: 0.15em;
 }
 
@@ -322,11 +334,11 @@
 }
 
 .roleLabel {
-    font-weight: 600;
+    font-weight: var(--font-weight-semibold);
 }
 
 .pendingLabel {
-    font-size: 0.85rem;
+    font-size: var(--font-size-sm);
     color: var(--text-secondary);
 }
 
@@ -402,13 +414,19 @@
     display: flex;
     align-items: center;
     gap: 0.6em;
-    font-weight: 500;
+    font-weight: var(--font-weight-medium);
     padding: 0.45em 0.6em;
     border-radius: 0.55em;
     border: 1px solid transparent;
     transition:
         border 0.15s ease,
         background 0.15s ease;
+}
+
+.checkboxRow:has(input:focus-visible) {
+    border-color: var(--accent-primary);
+    outline: 0.125em solid var(--accent-secondary);
+    outline-offset: 0.125em;
 }
 
 .checkboxRow input {
@@ -430,8 +448,68 @@
 }
 
 .pendingLabelSmall {
-    font-size: 0.85rem;
+    margin-left: auto;
+    font-size: var(--font-size-sm);
     color: var(--text-secondary);
+}
+
+.participantGroup {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65em;
+}
+
+.participantGroupHeader {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1em;
+    text-align: left;
+}
+
+.participantGroupTitle {
+    margin: 0;
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-semibold);
+}
+
+.participantGroupHint {
+    margin: 0.2em 0 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    line-height: 1.4;
+}
+
+.participantCount,
+.pendingStatusBadge {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    padding: 0.2em 0.6em;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--card-secondary) 80%, transparent);
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-semibold);
+}
+
+.pendingParticipantsList {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+    padding: 0.6em 0.8em;
+    border-radius: 0.6em;
+    background: color-mix(in srgb, var(--card-secondary) 55%, transparent);
+}
+
+.pendingParticipantRow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1em;
+    padding: 0.45em 0.6em;
+    color: var(--text-secondary);
+    text-align: left;
 }
 
 .schemeList {

--- a/src/pages/group/ui/GroupPage/GroupPage.tsx
+++ b/src/pages/group/ui/GroupPage/GroupPage.tsx
@@ -42,6 +42,7 @@ import {
 } from "entities/duel-invitation";
 import { DuelConfigurationManager, DuelConfigurationPicker } from "features/duel-configuration";
 import configStyles from "features/duel-configuration/ui/DuelConfigurationManager.module.scss";
+import { getTournamentParticipantGroups } from "../../lib/tournamentParticipants";
 
 import styles from "./GroupPage.module.scss";
 
@@ -397,7 +398,11 @@ const GroupPage = () => {
             }
             handleExcludeClose();
         } catch {
-            setExcludeError("Не удалось исключить пользователя.");
+            setExcludeError(
+                excludeTarget.status === "Pending"
+                    ? "Не удалось отменить приглашение."
+                    : "Не удалось исключить пользователя.",
+            );
         }
     };
 
@@ -457,9 +462,12 @@ const GroupPage = () => {
         });
     }, [members]);
 
-    const selectableTournamentMembers = useMemo(() => {
-        return sortedMembers.filter((member) => Boolean(member.user.nickname));
-    }, [sortedMembers]);
+    const tournamentMemberGroups = useMemo(
+        () => getTournamentParticipantGroups(sortedMembers),
+        [sortedMembers],
+    );
+    const selectableTournamentMembers = tournamentMemberGroups.selectable;
+    const pendingTournamentMembers = tournamentMemberGroups.pending;
 
     const sortedGroupDuels = useMemo(() => {
         return [...(groupDuels ?? [])].sort((left, right) => {
@@ -640,10 +648,13 @@ const GroupPage = () => {
             return;
         }
         const participantNicknames = tournamentParticipants
-            .map((id) => members?.find((member) => member.user.id === id)?.user.nickname ?? "")
+            .map((id) => activeMembers.find((member) => member.user.id === id)?.user.nickname ?? "")
             .filter((nickname) => nickname.trim().length > 0);
-        if (participantNicknames.length === 0) {
-            setTournamentFormError("Не удалось определить участников турнира.");
+        if (participantNicknames.length !== tournamentParticipants.length) {
+            setTournamentFormError(
+                "Состав группы изменился. Выберите подтвержденных участников заново.",
+            );
+            setTournamentParticipants([]);
             setTournamentStep(2);
             return;
         }
@@ -906,7 +917,9 @@ const GroupPage = () => {
                                                                     isCancelingInvitation
                                                                 }
                                                             >
-                                                                Исключить
+                                                                {member.status === "Pending"
+                                                                    ? "Отменить приглашение"
+                                                                    : "Исключить"}
                                                             </Button>
                                                         )}
                                                     </div>
@@ -1370,9 +1383,18 @@ const GroupPage = () => {
             )}
 
             {excludeTarget && (
-                <Modal title="Исключить участника" onClose={handleExcludeClose}>
+                <Modal
+                    title={
+                        excludeTarget.status === "Pending"
+                            ? "Отменить приглашение"
+                            : "Исключить участника"
+                    }
+                    onClose={handleExcludeClose}
+                >
                     <p className={styles.excludeText}>
-                        Исключить {excludeTarget.user.nickname} из группы?
+                        {excludeTarget.status === "Pending"
+                            ? `Отменить приглашение для ${excludeTarget.user.nickname}?`
+                            : `Исключить ${excludeTarget.user.nickname} из группы?`}
                     </p>
                     {excludeError && <div className={styles.errorText}>{excludeError}</div>}
                     <div className={styles.formActions}>
@@ -1390,7 +1412,9 @@ const GroupPage = () => {
                             onClick={handleExcludeConfirm}
                             disabled={isExcluding || isCancelingInvitation}
                         >
-                            Исключить
+                            {excludeTarget.status === "Pending"
+                                ? "Отменить приглашение"
+                                : "Исключить"}
                         </Button>
                     </div>
                 </Modal>
@@ -1630,56 +1654,110 @@ const GroupPage = () => {
 
                         {tournamentStep === 2 && (
                             <div className={styles.tournamentStage}>
-                                <label
-                                    className={`${styles.checkboxRow} ${styles.checkboxRowHeader}`}
-                                >
-                                    <input
-                                        type="checkbox"
-                                        checked={isAllTournamentParticipantsSelected}
-                                        onChange={handleToggleSelectAllParticipants}
-                                        disabled={selectableTournamentMembers.length === 0}
-                                    />
-                                    Выбрать всех
-                                </label>
-                                <div className={styles.participantsList}>
-                                    {sortedMembers.length === 0 ? (
-                                        <div className={styles.searchEmpty}>
-                                            В группе пока нет участников.
+                                <div className={styles.participantGroup}>
+                                    <div className={styles.participantGroupHeader}>
+                                        <div>
+                                            <h4 className={styles.participantGroupTitle}>
+                                                Подтвержденные участники
+                                            </h4>
+                                            <p className={styles.participantGroupHint}>
+                                                Только они могут участвовать в турнире.
+                                            </p>
                                         </div>
-                                    ) : (
-                                        sortedMembers.map((member) => {
-                                            const nickname = member.user.nickname ?? "Без никнейма";
-                                            const isDisabled = !member.user.nickname;
-                                            return (
-                                                <label
-                                                    key={member.user.id}
-                                                    className={`${styles.checkboxRow} ${
-                                                        isDisabled ? styles.checkboxDisabled : ""
-                                                    }`}
-                                                >
-                                                    <input
-                                                        type="checkbox"
-                                                        checked={tournamentParticipantSet.has(
-                                                            member.user.id,
-                                                        )}
-                                                        onChange={() =>
-                                                            toggleTournamentParticipant(
+                                        <span className={styles.participantCount}>
+                                            {tournamentMemberGroups.accepted.length}
+                                        </span>
+                                    </div>
+                                    <label
+                                        className={`${styles.checkboxRow} ${styles.checkboxRowHeader}`}
+                                    >
+                                        <input
+                                            type="checkbox"
+                                            checked={isAllTournamentParticipantsSelected}
+                                            onChange={handleToggleSelectAllParticipants}
+                                            disabled={selectableTournamentMembers.length === 0}
+                                        />
+                                        Выбрать всех доступных
+                                    </label>
+                                    <div className={styles.participantsList}>
+                                        {tournamentMemberGroups.accepted.length === 0 ? (
+                                            <div className={styles.searchEmpty}>
+                                                Нет подтвержденных участников.
+                                            </div>
+                                        ) : (
+                                            tournamentMemberGroups.accepted.map((member) => {
+                                                const nickname =
+                                                    member.user.nickname ?? "Без никнейма";
+                                                const isDisabled = !member.user.nickname;
+                                                return (
+                                                    <label
+                                                        key={member.user.id}
+                                                        className={`${styles.checkboxRow} ${
+                                                            isDisabled
+                                                                ? styles.checkboxDisabled
+                                                                : ""
+                                                        }`}
+                                                    >
+                                                        <input
+                                                            type="checkbox"
+                                                            checked={tournamentParticipantSet.has(
                                                                 member.user.id,
-                                                            )
-                                                        }
-                                                        disabled={isDisabled}
-                                                    />
-                                                    <span>{nickname}</span>
-                                                    {member.status === "Pending" && (
-                                                        <span className={styles.pendingLabelSmall}>
-                                                            (не подтвержден)
-                                                        </span>
-                                                    )}
-                                                </label>
-                                            );
-                                        })
-                                    )}
+                                                            )}
+                                                            onChange={() =>
+                                                                toggleTournamentParticipant(
+                                                                    member.user.id,
+                                                                )
+                                                            }
+                                                            disabled={isDisabled}
+                                                        />
+                                                        <span>{nickname}</span>
+                                                        {isDisabled && (
+                                                            <span
+                                                                className={styles.pendingLabelSmall}
+                                                            >
+                                                                Недоступен без никнейма
+                                                            </span>
+                                                        )}
+                                                    </label>
+                                                );
+                                            })
+                                        )}
+                                    </div>
                                 </div>
+
+                                {pendingTournamentMembers.length > 0 && (
+                                    <div className={styles.participantGroup}>
+                                        <div className={styles.participantGroupHeader}>
+                                            <div>
+                                                <h4 className={styles.participantGroupTitle}>
+                                                    Ожидают подтверждения
+                                                </h4>
+                                                <p className={styles.participantGroupHint}>
+                                                    Станут доступны после принятия приглашения в
+                                                    группу.
+                                                </p>
+                                            </div>
+                                            <span className={styles.participantCount}>
+                                                {pendingTournamentMembers.length}
+                                            </span>
+                                        </div>
+                                        <div className={styles.pendingParticipantsList}>
+                                            {pendingTournamentMembers.map((member) => (
+                                                <div
+                                                    key={member.user.id}
+                                                    className={styles.pendingParticipantRow}
+                                                >
+                                                    <span>
+                                                        {member.user.nickname ?? "Без никнейма"}
+                                                    </span>
+                                                    <span className={styles.pendingStatusBadge}>
+                                                        Недоступен
+                                                    </span>
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                         )}
 

--- a/src/pages/groups/ui/GroupsPage/GroupsPage.module.scss
+++ b/src/pages/groups/ui/GroupsPage/GroupsPage.module.scss
@@ -1,4 +1,6 @@
 .groupsPage {
+    font-family: var(--font-family-sans);
+    font-size: var(--font-size-md);
     display: flex;
     justify-content: center;
     padding: 2em 1.5em 3em;
@@ -40,7 +42,8 @@
 }
 
 .title {
-    font-size: 1.5rem;
+    font-size: var(--font-size-xl);
+    font-weight: var(--font-weight-bold);
     margin-bottom: 0;
 }
 
@@ -89,6 +92,11 @@
     background: var(--card-secondary);
 }
 
+.groupLink:focus-visible {
+    outline: 0.125em solid var(--accent-secondary);
+    outline-offset: 0.125em;
+}
+
 .groupLink {
     display: block;
     width: 100%;
@@ -114,8 +122,8 @@
 }
 
 .sectionTitle {
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-semibold);
 }
 
 .searchRow {

--- a/src/shared/lib/dismissibleLayerStack.test.ts
+++ b/src/shared/lib/dismissibleLayerStack.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { createDismissibleLayerStack } from "./dismissibleLayerStack";
+
+describe("dismissibleLayerStack", () => {
+    it("allows only the most recently opened layer to handle dismissal", () => {
+        const stack = createDismissibleLayerStack();
+        const parent = stack.register();
+        const child = stack.register();
+
+        expect(parent.isTopmost()).toBe(false);
+        expect(child.isTopmost()).toBe(true);
+
+        child.unregister();
+
+        expect(child.isTopmost()).toBe(false);
+        expect(parent.isTopmost()).toBe(true);
+    });
+
+    it("removes a non-topmost layer without disturbing the active child", () => {
+        const stack = createDismissibleLayerStack();
+        const parent = stack.register();
+        const child = stack.register();
+
+        parent.unregister();
+        parent.unregister();
+
+        expect(parent.isTopmost()).toBe(false);
+        expect(child.isTopmost()).toBe(true);
+    });
+});

--- a/src/shared/lib/dismissibleLayerStack.ts
+++ b/src/shared/lib/dismissibleLayerStack.ts
@@ -1,0 +1,33 @@
+interface DismissibleLayerRegistration {
+    isTopmost: () => boolean;
+    unregister: () => void;
+}
+
+export const createDismissibleLayerStack = () => {
+    const layers: symbol[] = [];
+
+    return {
+        register(): DismissibleLayerRegistration {
+            const layerId = Symbol("dismissible-layer");
+            let isRegistered = true;
+            layers.push(layerId);
+
+            return {
+                isTopmost: () => isRegistered && layers[layers.length - 1] === layerId,
+                unregister: () => {
+                    if (!isRegistered) return;
+                    isRegistered = false;
+
+                    const index = layers.lastIndexOf(layerId);
+                    if (index !== -1) {
+                        layers.splice(index, 1);
+                    }
+                },
+            };
+        },
+    };
+};
+
+const dismissibleLayerStack = createDismissibleLayerStack();
+
+export const registerDismissibleLayer = () => dismissibleLayerStack.register();

--- a/src/shared/lib/useDismissibleLayer.ts
+++ b/src/shared/lib/useDismissibleLayer.ts
@@ -1,5 +1,7 @@
 import { useEffect, useRef, type RefObject } from "react";
 
+import { registerDismissibleLayer } from "./dismissibleLayerStack";
+
 const focusableSelector = [
     "button:not([disabled])",
     "[href]",
@@ -41,6 +43,7 @@ export const useDismissibleLayer = ({
     useEffect(() => {
         if (!isOpen) return;
 
+        const layerRegistration = registerDismissibleLayer();
         const previouslyFocused =
             document.activeElement instanceof HTMLElement ? document.activeElement : null;
         const layer = layerRef.current;
@@ -56,6 +59,7 @@ export const useDismissibleLayer = ({
         };
 
         const handleKeyDown = (event: KeyboardEvent) => {
+            if (!layerRegistration.isTopmost()) return;
             if (!isFocusInsideLayer()) return;
 
             if (event.key === "Escape") {
@@ -88,6 +92,7 @@ export const useDismissibleLayer = ({
         };
 
         const handleMouseDown = (event: MouseEvent) => {
+            if (!layerRegistration.isTopmost()) return;
             if (!closeOnOutsidePress || !layerRef.current) return;
             if (event.target instanceof Node && !layerRef.current.contains(event.target)) {
                 onDismissRef.current();
@@ -102,6 +107,7 @@ export const useDismissibleLayer = ({
         return () => {
             document.removeEventListener("keydown", handleKeyDown);
             document.removeEventListener("mousedown", handleMouseDown);
+            layerRegistration.unregister();
 
             if (previouslyFocused?.isConnected) {
                 previouslyFocused.focus();

--- a/src/shared/lib/useDismissibleLayer.ts
+++ b/src/shared/lib/useDismissibleLayer.ts
@@ -1,0 +1,111 @@
+import { useEffect, useRef, type RefObject } from "react";
+
+const focusableSelector = [
+    "button:not([disabled])",
+    "[href]",
+    "input:not([disabled])",
+    "select:not([disabled])",
+    "textarea:not([disabled])",
+    '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+interface UseDismissibleLayerOptions {
+    isOpen: boolean;
+    layerRef: RefObject<HTMLElement | null>;
+    onDismiss: () => void;
+    closeOnOutsidePress?: boolean;
+    focusOnOpen?: boolean;
+    trapFocus?: boolean;
+}
+
+const getFocusableElements = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll<HTMLElement>(focusableSelector)).filter(
+        (element) =>
+            !element.hasAttribute("hidden") && element.getAttribute("aria-hidden") !== "true",
+    );
+
+export const useDismissibleLayer = ({
+    isOpen,
+    layerRef,
+    onDismiss,
+    closeOnOutsidePress = false,
+    focusOnOpen = false,
+    trapFocus = false,
+}: UseDismissibleLayerOptions) => {
+    const onDismissRef = useRef(onDismiss);
+
+    useEffect(() => {
+        onDismissRef.current = onDismiss;
+    }, [onDismiss]);
+
+    useEffect(() => {
+        if (!isOpen) return;
+
+        const previouslyFocused =
+            document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        const layer = layerRef.current;
+
+        if (focusOnOpen && layer) {
+            const [firstFocusable] = getFocusableElements(layer);
+            (firstFocusable ?? layer).focus();
+        }
+
+        const isFocusInsideLayer = () => {
+            const activeElement = document.activeElement;
+            return !layerRef.current || !activeElement || layerRef.current.contains(activeElement);
+        };
+
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (!isFocusInsideLayer()) return;
+
+            if (event.key === "Escape") {
+                event.preventDefault();
+                event.stopPropagation();
+                onDismissRef.current();
+                return;
+            }
+
+            if (event.key !== "Tab" || !trapFocus || !layerRef.current) return;
+
+            const focusableElements = getFocusableElements(layerRef.current);
+            if (focusableElements.length === 0) {
+                event.preventDefault();
+                layerRef.current.focus();
+                return;
+            }
+
+            const firstFocusable = focusableElements[0];
+            const lastFocusable = focusableElements[focusableElements.length - 1];
+            const activeElement = document.activeElement;
+
+            if (event.shiftKey && activeElement === firstFocusable) {
+                event.preventDefault();
+                lastFocusable.focus();
+            } else if (!event.shiftKey && activeElement === lastFocusable) {
+                event.preventDefault();
+                firstFocusable.focus();
+            }
+        };
+
+        const handleMouseDown = (event: MouseEvent) => {
+            if (!closeOnOutsidePress || !layerRef.current) return;
+            if (event.target instanceof Node && !layerRef.current.contains(event.target)) {
+                onDismissRef.current();
+            }
+        };
+
+        document.addEventListener("keydown", handleKeyDown);
+        if (closeOnOutsidePress) {
+            document.addEventListener("mousedown", handleMouseDown);
+        }
+
+        return () => {
+            document.removeEventListener("keydown", handleKeyDown);
+            document.removeEventListener("mousedown", handleMouseDown);
+
+            if (previouslyFocused?.isConnected) {
+                previouslyFocused.focus();
+            }
+        };
+    }, [closeOnOutsidePress, focusOnOpen, isOpen, layerRef, trapFocus]);
+};

--- a/src/shared/ui/DropdownMenu/DropdownMenu.module.scss
+++ b/src/shared/ui/DropdownMenu/DropdownMenu.module.scss
@@ -4,7 +4,18 @@
 }
 
 .dropdownTrigger {
+    display: block;
+    width: 100%;
+    padding: 0;
+
     cursor: pointer;
+    color: inherit;
+    text-align: inherit;
+
+    &:focus-visible {
+        outline: 0.125em solid var(--accent-secondary);
+        outline-offset: 0.125em;
+    }
 }
 
 .dropdownMenu {
@@ -26,6 +37,7 @@
 }
 
 .dropdownItem {
+    width: 100%;
     display: flex;
     align-items: center;
     column-gap: 0.75em;
@@ -36,6 +48,15 @@
 
     font-size: 1em;
     font-weight: 400;
+    color: var(--text-primary);
+    text-align: left;
+
+    &:is(button):hover,
+    &:is(button):focus-visible {
+        border-radius: 0.35em;
+        background: var(--card-secondary);
+        outline: none;
+    }
 
     .listIcon {
         color: var(--text-primary);

--- a/src/shared/ui/DropdownMenu/DropdownMenu.test.tsx
+++ b/src/shared/ui/DropdownMenu/DropdownMenu.test.tsx
@@ -1,0 +1,21 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { DropdownMenu } from "./DropdownMenu";
+
+describe("DropdownMenu", () => {
+    it("renders a semantic keyboard-focusable popover trigger", () => {
+        const markup = renderToStaticMarkup(
+            <DropdownMenu
+                trigger={<span>Профиль</span>}
+                triggerAriaLabel="Открыть меню пользователя"
+                items={[{ label: "Выйти", onClick: () => undefined }]}
+            />,
+        );
+
+        expect(markup).toContain("<button");
+        expect(markup).toContain('aria-label="Открыть меню пользователя"');
+        expect(markup).toContain('aria-haspopup="menu"');
+        expect(markup).toContain('aria-expanded="false"');
+    });
+});

--- a/src/shared/ui/DropdownMenu/DropdownMenu.tsx
+++ b/src/shared/ui/DropdownMenu/DropdownMenu.tsx
@@ -1,5 +1,5 @@
-import { ReactNode, useEffect, useRef, useState } from "react";
-import { assertIsNode } from "shared/lib/typeAssertions";
+import { ReactNode, useCallback, useRef, useState } from "react";
+import { useDismissibleLayer } from "shared/lib/useDismissibleLayer";
 import clsx from "clsx";
 
 import styles from "./DropdownMenu.module.scss";
@@ -20,6 +20,8 @@ interface Props {
     menuClassName?: string;
     itemClassName?: string;
     onOpenChange?: (open: boolean) => void;
+    triggerAriaLabel?: string;
+    popoverRole?: "menu" | "dialog";
 }
 
 export const DropdownMenu = ({
@@ -30,36 +32,39 @@ export const DropdownMenu = ({
     menuClassName,
     itemClassName,
     onOpenChange,
+    triggerAriaLabel,
+    popoverRole = "menu",
 }: Props) => {
     const [open, setOpen] = useState(false);
     const menuRef = useRef<HTMLDivElement>(null);
 
+    const closeMenu = useCallback(() => {
+        setOpen(false);
+        onOpenChange?.(false);
+    }, [onOpenChange]);
+
+    useDismissibleLayer({
+        isOpen: open,
+        layerRef: menuRef,
+        onDismiss: closeMenu,
+        closeOnOutsidePress: true,
+    });
+
     const handleItemOnClick = (item: DropdownItem) => {
         item.onClick?.();
         if (item.closeOnClick !== false) {
-            setOpen(false);
+            closeMenu();
         }
     };
-
-    const handleClickOutside = ({ target }: MouseEvent) => {
-        assertIsNode(target);
-        if (menuRef.current && !menuRef.current.contains(target)) {
-            setOpen(false);
-            onOpenChange?.(false);
-        }
-    };
-
-    useEffect(() => {
-        document.addEventListener("mousedown", handleClickOutside);
-        return () => {
-            document.removeEventListener("mousedown", handleClickOutside);
-        };
-    }, []);
 
     return (
         <div ref={menuRef} className={clsx(styles.dropdown, dropdownClassName)}>
-            <div
+            <button
+                type="button"
                 className={clsx(styles.dropdownTrigger, triggerClassName)}
+                aria-label={triggerAriaLabel}
+                aria-haspopup={popoverRole}
+                aria-expanded={open}
                 onClick={() => {
                     const nextOpen = !open;
                     setOpen(nextOpen);
@@ -67,20 +72,37 @@ export const DropdownMenu = ({
                 }}
             >
                 {trigger}
-            </div>
+            </button>
             {open && (
-                <ul className={clsx(styles.dropdownMenu, menuClassName)}>
-                    {items.map((item, index) => (
-                        <li
-                            className={clsx(styles.dropdownItem, itemClassName)}
-                            key={item.id ?? index}
-                            onClick={() => handleItemOnClick(item)}
-                        >
-                            {item.icon && <span className={styles.listIcon}>{item.icon}</span>}
-                            {item.label}
-                        </li>
-                    ))}
-                </ul>
+                <div
+                    className={clsx(styles.dropdownMenu, menuClassName)}
+                    role={popoverRole}
+                    aria-label={triggerAriaLabel}
+                >
+                    {items.map((item, index) =>
+                        item.onClick ? (
+                            <button
+                                key={item.id ?? index}
+                                type="button"
+                                role={popoverRole === "menu" ? "menuitem" : undefined}
+                                className={clsx(styles.dropdownItem, itemClassName)}
+                                onClick={() => handleItemOnClick(item)}
+                            >
+                                {item.icon && <span className={styles.listIcon}>{item.icon}</span>}
+                                {item.label}
+                            </button>
+                        ) : (
+                            <div
+                                key={item.id ?? index}
+                                role={popoverRole === "menu" ? "none" : undefined}
+                                className={clsx(styles.dropdownItem, itemClassName)}
+                            >
+                                {item.icon && <span className={styles.listIcon}>{item.icon}</span>}
+                                {item.label}
+                            </div>
+                        ),
+                    )}
+                </div>
             )}
         </div>
     );

--- a/src/shared/ui/Modal/Modal.module.scss
+++ b/src/shared/ui/Modal/Modal.module.scss
@@ -14,7 +14,10 @@
 
 .modal {
     position: relative;
-    min-width: 25em;
+    min-width: min(25em, 100%);
+    max-width: 100%;
+    max-height: calc(100dvh - 4em);
+    overflow: auto;
 
     padding: 2em;
 
@@ -23,6 +26,11 @@
     box-shadow: 0 2.5em 4em rgba(0, 0, 0, 0.3);
 
     text-align: center;
+
+    &:focus-visible {
+        outline: 0.125em solid var(--accent-secondary);
+        outline-offset: 0.125em;
+    }
 }
 
 .title {
@@ -30,6 +38,21 @@
     font-size: 1.5em;
     font-weight: 700;
     color: var(--text-primary);
+}
+
+@media (max-width: 600px) {
+    .overlay {
+        align-items: flex-start;
+        padding: 1em;
+        overflow: auto;
+    }
+
+    .modal {
+        width: 100%;
+        min-width: 0;
+        max-height: none;
+        padding: 1.5em 1em;
+    }
 }
 
 .closeButton {

--- a/src/shared/ui/Modal/Modal.test.tsx
+++ b/src/shared/ui/Modal/Modal.test.tsx
@@ -1,0 +1,21 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { Modal } from "./Modal";
+
+describe("Modal", () => {
+    it("connects the dialog to its visible title", () => {
+        const markup = renderToStaticMarkup(
+            <Modal title="Подтверждение" onClose={() => undefined}>
+                <button type="button">Продолжить</button>
+            </Modal>,
+        );
+
+        const titleId = markup.match(/<h3 id="([^"]+)"/)?.[1];
+
+        expect(titleId).toBeTruthy();
+        expect(markup).toContain('role="dialog"');
+        expect(markup).toContain('aria-modal="true"');
+        expect(markup).toContain(`aria-labelledby="${titleId}"`);
+    });
+});

--- a/src/shared/ui/Modal/Modal.tsx
+++ b/src/shared/ui/Modal/Modal.tsx
@@ -1,6 +1,7 @@
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, useId, useRef } from "react";
 
 import CrossIcon from "shared/assets/icons/cross.svg?react";
+import { useDismissibleLayer } from "shared/lib/useDismissibleLayer";
 import { IconButton } from "../IconButton/IconButton";
 
 import styles from "./Modal.module.scss";
@@ -19,13 +20,34 @@ export const Modal = ({
     closeOnOverlay = true,
     children,
 }: PropsWithChildren<Props>) => {
+    const modalRef = useRef<HTMLDivElement>(null);
+    const titleId = useId();
+
+    useDismissibleLayer({
+        isOpen: true,
+        layerRef: modalRef,
+        onDismiss: onClose,
+        focusOnOpen: true,
+        trapFocus: true,
+    });
+
     return (
         <div
             className={styles.overlay}
-            role="dialog"
-            onClick={closeOnOverlay ? onClose : undefined}
+            onClick={(event) => {
+                if (closeOnOverlay && event.currentTarget === event.target) {
+                    onClose();
+                }
+            }}
         >
-            <div className={styles.modal} onClick={(event) => event.stopPropagation()}>
+            <div
+                ref={modalRef}
+                className={styles.modal}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby={titleId}
+                tabIndex={-1}
+            >
                 {showCloseButton && (
                     <IconButton
                         className={styles.closeButton}
@@ -36,7 +58,9 @@ export const Modal = ({
                         <CrossIcon />
                     </IconButton>
                 )}
-                <h3 className={styles.title}>{title}</h3>
+                <h3 id={titleId} className={styles.title}>
+                    {title}
+                </h3>
                 {children}
             </div>
         </div>

--- a/src/shared/ui/ResultTitle/ResultTitle.tsx
+++ b/src/shared/ui/ResultTitle/ResultTitle.tsx
@@ -25,9 +25,9 @@ export const ResultTitle = ({ variant, children }: PropsWithChildren<Props>) => 
     };
 
     return (
-        <div className={getClassName()}>
+        <span className={getClassName()}>
             {iconsMap[variant]}
             {children}
-        </div>
+        </span>
     );
 };

--- a/src/widgets/header/ui/Header.module.scss
+++ b/src/widgets/header/ui/Header.module.scss
@@ -1,9 +1,12 @@
 .header {
     grid-area: header;
 
-    display: flex;
-    justify-content: space-between;
+    min-height: 70px;
+    display: grid;
+    grid-template-areas: "left center right";
+    grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
+    column-gap: 1em;
 
     padding: 0.75em 1.25em;
 
@@ -11,21 +14,56 @@
 }
 
 .left {
+    grid-area: left;
     display: flex;
     align-items: center;
     gap: 1em;
 }
 
 .center {
+    grid-area: center;
     display: flex;
     justify-content: center;
-    flex: 1;
+    min-width: 0;
 
-    margin-left: -2.5em;
+    &:empty {
+        display: none;
+    }
 }
 
 .right {
+    grid-area: right;
     display: flex;
     align-items: center;
     gap: 0.75em;
+    min-width: 0;
+}
+
+.userMenuTrigger {
+    border-radius: 0.6em;
+    transition: background 0.15s ease;
+
+    &:hover {
+        background: color-mix(in srgb, var(--card-secondary) 65%, transparent);
+    }
+}
+
+@media (max-width: 900px) {
+    .header:has(.center:not(:empty)) {
+        grid-template-areas:
+            "left right"
+            "center center";
+        grid-template-columns: minmax(0, 1fr) auto;
+        row-gap: 0.75em;
+    }
+}
+
+@media (max-width: 560px) {
+    .header {
+        padding-inline: 0.75em;
+    }
+
+    .left {
+        gap: 0.5em;
+    }
 }

--- a/src/widgets/header/ui/Header.tsx
+++ b/src/widgets/header/ui/Header.tsx
@@ -63,9 +63,13 @@ export const Header = () => {
             <div className={styles.right}>
                 {user && (
                     <DropdownMenu
-                        trigger={<UserCard user={user} hideInfo={Boolean(duelId)} />}
+                        trigger={
+                            <UserCard user={user} hideInfo={Boolean(duelId)} compactOnMobile />
+                        }
                         items={userMenuItems}
                         onOpenChange={setIsUserMenuOpen}
+                        triggerClassName={styles.userMenuTrigger}
+                        triggerAriaLabel={`Открыть меню пользователя ${user.nickname}`}
                     />
                 )}
             </div>

--- a/src/widgets/task-panel/ui/TaskSubmissionCodeContent/TaskSubmissionCodeContent.tsx
+++ b/src/widgets/task-panel/ui/TaskSubmissionCodeContent/TaskSubmissionCodeContent.tsx
@@ -117,6 +117,8 @@ export const TaskSubmissionCodeContent = () => {
                             triggerClassName={styles.messageDropdownTrigger}
                             menuClassName={styles.messageDropdownMenu}
                             itemClassName={styles.messageDropdownItem}
+                            triggerAriaLabel="Показать сообщение проверки"
+                            popoverRole="dialog"
                         />
                     ) : (
                         <ResultTitle variant={variant}>{displayText}</ResultTitle>


### PR DESCRIPTION
## Summary

- prevent the responsive header from overlapping page content and make the user avatar a consistent accessible trigger
- centralize Escape, outside-press, focus return, and modal focus trapping in a reusable dismissible-layer hook
- ensure nested dismissible layers close one at a time, starting with the topmost layer
- align group typography with design tokens and separate pending tournament participants from selectable confirmed members
- clarify pending invitation actions and document the updated group/tournament behavior

## Verification

- TypeScript and ESLint passed (6 existing warnings)
- Vitest: 14 files, 27 tests passed
- Production build passed with `VITE_BASE_URL=http://217.198.9.97/api`
- Headless Chrome smoke tests passed for public and authenticated cold startup
- Nested-modal smoke test confirmed the first Escape closes only the delete confirmation; the second closes the parent and restores focus
- FSD check still reports 13 existing errors and 11 warnings in pre-existing files; changed files add no new violations

Closes #67