### PR TITLE
fix(friendly-duel): isolate cancellation flow

### DIFF
--- a/docs/processes/duel-invitations.md
+++ b/docs/processes/duel-invitations.md
@@ -70,7 +70,9 @@ sequenceDiagram
 Friendly creation moves its widget through `configuring -> pending`; the
 corresponding session moves `idle -> searching`. `DuelStarted` moves a pending
 session to `active`, and the widget to `matched`. A `DuelStarted` received after
-an already-cancelled session is ignored instead of reviving that duel.
+an already-cancelled session is ignored instead of reviving that duel; an idle
+sibling tab without such a cancellation fence still accepts its authoritative
+start event.
 
 Successful user cancellation moves the widget to `canceled` with reason `user`.
 Cancellation from the server and an established socket disconnect also reach

--- a/docs/processes/duel-invitations.md
+++ b/docs/processes/duel-invitations.md
@@ -25,10 +25,19 @@ pending. UI visibility is not authorization.
 
 ## Current behavior
 
-Direct creation calls `POST /duels/invitations`; on success the sender persists
-opponent/configuration/type `Friendly` and enters searching. Home queries direct
-pending invitations using argument `Ranked`, although the backend domain calls
-them friendly; its transform labels the returned item `Ranked`. Direct accept,
+Direct creation is owned by the `friendly-duel` widget. Its explicit client state
+machine is `idle -> configuring -> pending -> matched|canceled|error`. It calls
+`POST /duels/invitations`; while the request is in flight, it stores the
+nickname/configuration/type `Friendly` in `duelSession` and enters searching so
+an early `DuelStarted` can still be accepted. User cancellation calls the
+direct-invitation cancel endpoint with the same nickname and configuration,
+rather than the generic matchmaking cancel endpoint. The selected rules and
+nickname remain in the widget after a cancellation, ready for another attempt.
+Configuration queries mount only while the configuration scenario is open.
+
+Home queries direct pending invitations using argument `Ranked`, although the
+backend domain calls them friendly; its transform labels the returned item
+`Ranked`. Direct accept,
 group-duel accept, and tournament accept wait for HTTP success, persist selected
 matching fields, set Home's `waitingForStart`, and wait for `DuelStarted`.
 Group-duel acceptance from either Home or the group page records the `Group`
@@ -58,7 +67,18 @@ sequenceDiagram
 
 ## Client state transitions
 
-Create/accept moves `idle -> searching`; `DuelStarted` moves to `active`.
+Friendly creation moves its widget through `configuring -> pending`; the
+corresponding session moves `idle -> searching`. `DuelStarted` moves a pending
+session to `active`, and the widget to `matched`. A `DuelStarted` received after
+an already-cancelled session is ignored instead of reviving that duel.
+
+Successful user cancellation moves the widget to `canceled` with reason `user`.
+Cancellation from the server and an established socket disconnect also reach
+`canceled`, but retain distinct reasons for the UI. A creation error moves the
+widget to `error`; a cancellation error leaves the pending invitation visible
+and re-enables its cancel button.
+
+Other create/accept flows move `idle -> searching`; `DuelStarted` moves to `active`.
 Cancellation/denial returns to idle only when event nickname/configuration and,
 for tournaments, tournament ID match persisted fields. Cancellation additionally
 requires the pending invitation family to match (`Friendly`/`Ranked`, `Group`,
@@ -77,17 +97,20 @@ matching rule may not reset the inviter.
 ## State ownership
 
 Invitation lists are RTK snapshots. Pending outgoing/accepted matching values
-are persisted in duelSession. Home panel visibility, pending nickname/ID, and
-`waitingForStart` are sessionStorage values, not backend facts and not
-user-scoped. Duely owns invitation existence and acceptance.
+are persisted in duelSession. The friendly widget keeps its configuration/nickname
+in non-persisted Redux state, restores its pending projection from the matching
+session fields after reload, and clears it after matching or explicit close.
+Home's pending invitation IDs and `waitingForStart` remain sessionStorage values,
+not backend facts and not user-scoped. Duely owns invitation existence and
+acceptance.
 
 ## UI effects
 
 Home aggregates direct, group-duel, tournament-duel, and group-membership cards.
-Forms/panels disable or display pending state using local/session values. A
-stale pending nickname or group invitation ID can keep controls disabled after
-reload. Group/tournament duel invitations offer accept but no symmetric deny in
-the current UI.
+The friendly widget owns its configuration panels, pending cancel control, and
+matched/canceled/error UI; it does not share stale panel flags with Home. Its
+buttons are serialized while a create/cancel request is pending. Group/tournament
+duel invitations offer accept but no symmetric deny in the current UI.
 
 ## Network effects
 
@@ -115,8 +138,10 @@ can be ignored or reset the wrong flow.
 
 ## Failure handling
 
-HTTP errors remain local; `409` has special friendly-create messaging. A lost
-success response can leave a backend-accepted invitation while UI remains idle.
+HTTP errors remain local; `409` has special friendly-create messaging. A failed
+friendly create returns to an actionable error state; a failed cancel does not
+leave its control disabled. A lost success response can leave a backend-accepted
+invitation while UI remains idle.
 Unknown/malformed WebSocket events are isolated. Every reconnect fetches the
 active duel and all active invitation lists, but the backend still exposes no
 single query for the precise outgoing pending workflow.
@@ -130,6 +155,7 @@ be presented to another user in the same tab.
 
 ## Implementation references
 
+- `src/widgets/friendly-duel/`
 - `src/pages/home/ui/HomePage.tsx`
 - invitation APIs under `src/entities/duel-invitation`
 - group invitation and group-duel APIs under `src/entities/group`
@@ -138,7 +164,9 @@ be presented to another user in the same tab.
 
 ## Test coverage
 
-- **Existing tests:** parser/router tests cover typed event isolation, and
+- **Existing tests:** friendly state-machine tests cover transitions, duplicate
+  cancellation, late match after cancellation, mutation recovery, and conditional
+  configuration loading; parser/router tests cover typed event isolation, and
   realtime integration covers duplicate/unknown events and reconnect lifecycle.
 - **Needed integration:** all four invitation families, exact event types/fields,
   accept/event order permutations, duplicate accepts, cancellation matching.

--- a/docs/processes/duel-session-lifecycle.md
+++ b/docs/processes/duel-session-lifecycle.md
@@ -56,10 +56,12 @@ as `DuelFinished`, so a silently missed socket event does not require F5.
 `setPhase("searching")` is ignored once an active ID exists. This fences the
 race where an early `DuelStarted` arrives before the search/accept HTTP response
 and that later response tries to put the already-active session back into
-searching. `DuelStarted` itself is accepted only while the session is searching;
-an event delivered after a successful cancellation therefore cannot revive a
-cancelled duel. Navigation from searching to active still belongs to mounted
-workflow components; the socket manager itself does not navigate.
+searching. `DuelStarted` is accepted while searching and also by an unfenced
+idle sibling tab, so a duel created in another tab remains reachable. Leaving a
+search fences late start events until the next search begins, so an event
+delivered after cancellation cannot revive the cancelled duel. Navigation from
+searching to active still belongs to mounted workflow components; the socket
+manager itself does not navigate.
 
 ```mermaid
 sequenceDiagram
@@ -81,7 +83,7 @@ sequenceDiagram
 ## Client state transitions
 
 - Ranked/friendly/accept success: `idle -> searching`.
-- `DuelStarted`: `searching -> active`, non-null active ID.
+- `DuelStarted`: `searching|unfenced idle -> active`, non-null active ID.
 - cancel success/socket close while searching: `searching -> idle`.
 - finish: matching user-owned `active -> idle`, ID null, pending result recorded.
 - acknowledgement/logout/reset: pending result cleared; logout/reset also returns

--- a/docs/processes/duel-session-lifecycle.md
+++ b/docs/processes/duel-session-lifecycle.md
@@ -58,10 +58,10 @@ race where an early `DuelStarted` arrives before the search/accept HTTP response
 and that later response tries to put the already-active session back into
 searching. `DuelStarted` is accepted while searching and also by an unfenced
 idle sibling tab, so a duel created in another tab remains reachable. Leaving a
-search fences late start events until the next search begins, so an event
-delivered after cancellation cannot revive the cancelled duel. Navigation from
-searching to active still belongs to mounted workflow components; the socket
-manager itself does not navigate.
+search sets a short-lived cancellation fence for late start events; after that
+window, the idle tab again accepts an authoritative start from a sibling tab.
+Navigation from searching to active still belongs to mounted workflow
+components; the socket manager itself does not navigate.
 
 ```mermaid
 sequenceDiagram

--- a/docs/processes/duel-session-lifecycle.md
+++ b/docs/processes/duel-session-lifecycle.md
@@ -56,8 +56,10 @@ as `DuelFinished`, so a silently missed socket event does not require F5.
 `setPhase("searching")` is ignored once an active ID exists. This fences the
 race where an early `DuelStarted` arrives before the search/accept HTTP response
 and that later response tries to put the already-active session back into
-searching. Navigation from searching to active still belongs to mounted workflow
-components; the socket manager itself does not navigate.
+searching. `DuelStarted` itself is accepted only while the session is searching;
+an event delivered after a successful cancellation therefore cannot revive a
+cancelled duel. Navigation from searching to active still belongs to mounted
+workflow components; the socket manager itself does not navigate.
 
 ```mermaid
 sequenceDiagram
@@ -79,7 +81,7 @@ sequenceDiagram
 ## Client state transitions
 
 - Ranked/friendly/accept success: `idle -> searching`.
-- `DuelStarted`: `idle|searching -> active`, non-null active ID.
+- `DuelStarted`: `searching -> active`, non-null active ID.
 - cancel success/socket close while searching: `searching -> idle`.
 - finish: matching user-owned `active -> idle`, ID null, pending result recorded.
 - acknowledgement/logout/reset: pending result cleared; logout/reset also returns

--- a/src/app/store.ts
+++ b/src/app/store.ts
@@ -3,6 +3,7 @@ import { persistReducer, persistStore } from "redux-persist";
 import storage from "redux-persist/lib/storage";
 import { authReducer } from "features/auth";
 import { duelSessionReducer } from "features/duel-session";
+import { friendlyDuelReducer } from "widgets/friendly-duel";
 import { codeEditorReducer } from "widgets/code-panel";
 import { themeReducer } from "features/theme";
 import { apiSlice } from "shared/api";
@@ -57,6 +58,7 @@ const store = configureStore({
         [apiSlice.reducerPath]: apiSlice.reducer,
         auth: persistedAuthReducer,
         duelSession: persistedDuelSessionReducer,
+        friendlyDuel: friendlyDuelReducer,
         codeEditor: persistedCodeEditorReducer,
         theme: persistedThemeReducer,
     },

--- a/src/features/duel-session/api/realtime/__tests__/duelHandlers.test.ts
+++ b/src/features/duel-session/api/realtime/__tests__/duelHandlers.test.ts
@@ -36,18 +36,40 @@ vi.mock("../../../model/duelSessionSlice", () => {
 const createState = (
     activeDuelId: number | null,
     phase: "idle" | "searching" | "active" = "active",
+    isDuelStartFenced = false,
 ) =>
     ({
         auth: { user: { id: 7 }, token: "token", refreshToken: "refresh" },
-        duelSession: { activeDuelId, phase },
+        duelSession: { activeDuelId, phase, isDuelStartFenced },
     }) as RootState;
 
 describe("duel realtime handlers", () => {
-    it("ignores a late start event after a pending search was canceled", () => {
+    it("accepts a start event received by an idle sibling tab", () => {
         const dispatch = vi.fn();
         const handlers = createDuelHandlers({
             dispatch: dispatch as unknown as AppDispatch,
             getState: () => createState(null, "idle"),
+            userId: 7,
+            reconcile: vi.fn(),
+        });
+
+        handlers.DuelStarted?.[0]({
+            type: "DuelStarted",
+            payload: { duel_id: 42 },
+            eventId: null,
+        });
+
+        expect(dispatch).toHaveBeenCalledWith({
+            type: "duelSession/setActiveDuel",
+            payload: { duelId: 42, userId: 7 },
+        });
+    });
+
+    it("ignores a late start event after a pending search was canceled", () => {
+        const dispatch = vi.fn();
+        const handlers = createDuelHandlers({
+            dispatch: dispatch as unknown as AppDispatch,
+            getState: () => createState(null, "idle", true),
             userId: 7,
             reconcile: vi.fn(),
         });

--- a/src/features/duel-session/api/realtime/__tests__/duelHandlers.test.ts
+++ b/src/features/duel-session/api/realtime/__tests__/duelHandlers.test.ts
@@ -33,13 +33,37 @@ vi.mock("../../../model/duelSessionSlice", () => {
     };
 });
 
-const createState = (activeDuelId: number | null) =>
+const createState = (
+    activeDuelId: number | null,
+    phase: "idle" | "searching" | "active" = "active",
+) =>
     ({
         auth: { user: { id: 7 }, token: "token", refreshToken: "refresh" },
-        duelSession: { activeDuelId },
+        duelSession: { activeDuelId, phase },
     }) as RootState;
 
 describe("duel realtime handlers", () => {
+    it("ignores a late start event after a pending search was canceled", () => {
+        const dispatch = vi.fn();
+        const handlers = createDuelHandlers({
+            dispatch: dispatch as unknown as AppDispatch,
+            getState: () => createState(null, "idle"),
+            userId: 7,
+            reconcile: vi.fn(),
+        });
+
+        handlers.DuelStarted?.[0]({
+            type: "DuelStarted",
+            payload: { duel_id: 42 },
+            eventId: null,
+        });
+
+        expect(dispatch).not.toHaveBeenCalledWith({
+            type: "duelSession/setActiveDuel",
+            payload: { duelId: 42, userId: 7 },
+        });
+    });
+
     it("turns a terminal event for the active duel into a pending result", () => {
         const dispatch = vi.fn();
         const handlers = createDuelHandlers({

--- a/src/features/duel-session/api/realtime/__tests__/duelHandlers.test.ts
+++ b/src/features/duel-session/api/realtime/__tests__/duelHandlers.test.ts
@@ -26,6 +26,7 @@ vi.mock("../../../model/duelSessionSlice", () => {
     const action = (type: string) => (payload?: unknown) => ({ type, payload });
     return {
         finishActiveDuel: action("duelSession/finishActiveDuel"),
+        clearDuelStartFence: action("duelSession/clearDuelStartFence"),
         resetDuelSession: action("duelSession/resetDuelSession"),
         setActiveDuel: action("duelSession/setActiveDuel"),
         setDuelCanceled: action("duelSession/setDuelCanceled"),
@@ -36,11 +37,11 @@ vi.mock("../../../model/duelSessionSlice", () => {
 const createState = (
     activeDuelId: number | null,
     phase: "idle" | "searching" | "active" = "active",
-    isDuelStartFenced = false,
+    duelStartFenceExpiresAt: number | null = null,
 ) =>
     ({
         auth: { user: { id: 7 }, token: "token", refreshToken: "refresh" },
-        duelSession: { activeDuelId, phase, isDuelStartFenced },
+        duelSession: { activeDuelId, phase, duelStartFenceExpiresAt },
     }) as RootState;
 
 describe("duel realtime handlers", () => {
@@ -69,7 +70,7 @@ describe("duel realtime handlers", () => {
         const dispatch = vi.fn();
         const handlers = createDuelHandlers({
             dispatch: dispatch as unknown as AppDispatch,
-            getState: () => createState(null, "idle", true),
+            getState: () => createState(null, "idle", Date.now() + 5_000),
             userId: 7,
             reconcile: vi.fn(),
         });
@@ -83,6 +84,56 @@ describe("duel realtime handlers", () => {
         expect(dispatch).not.toHaveBeenCalledWith({
             type: "duelSession/setActiveDuel",
             payload: { duelId: 42, userId: 7 },
+        });
+    });
+
+    it("accepts an idle start after the cancellation fence expires", () => {
+        const dispatch = vi.fn();
+        const handlers = createDuelHandlers({
+            dispatch: dispatch as unknown as AppDispatch,
+            getState: () => createState(null, "idle", Date.now() - 1),
+            userId: 7,
+            reconcile: vi.fn(),
+        });
+
+        handlers.DuelStarted?.[0]({
+            type: "DuelStarted",
+            payload: { duel_id: 42 },
+            eventId: null,
+        });
+
+        expect(dispatch).toHaveBeenCalledWith({ type: "duelSession/clearDuelStartFence" });
+        expect(dispatch).toHaveBeenCalledWith({
+            type: "duelSession/setActiveDuel",
+            payload: { duelId: 42, userId: 7 },
+        });
+    });
+
+    it("fences a late start after a server cancellation", () => {
+        const dispatch = vi.fn();
+        const handlers = createDuelHandlers({
+            dispatch: dispatch as unknown as AppDispatch,
+            getState: () =>
+                ({
+                    ...createState(null, "searching"),
+                    duelSession: {
+                        ...createState(null, "searching").duelSession,
+                        searchInvitationType: "Friendly",
+                    },
+                }) as RootState,
+            userId: 7,
+            reconcile: vi.fn(),
+        });
+
+        handlers.DuelCanceled?.[0]({
+            type: "DuelCanceled",
+            payload: { opponent_nickname: "opponent" },
+            eventId: null,
+        });
+
+        expect(dispatch).toHaveBeenCalledWith({
+            type: "duelSession/resetDuelSession",
+            payload: { fenceDuelStart: true },
         });
     });
 

--- a/src/features/duel-session/api/realtime/domain/duelHandlers.ts
+++ b/src/features/duel-session/api/realtime/domain/duelHandlers.ts
@@ -5,6 +5,7 @@ import { fromApiLanguage } from "shared/config";
 
 import {
     finishActiveDuel,
+    clearDuelStartFence,
     setActiveDuel,
     setDuelCanceled,
     setDuelCanceledOpponentNickname,
@@ -25,7 +26,13 @@ export const createDuelHandlers = (context: DomainEventContext): RealtimeEventHa
     DuelStarted: [
         ({ payload }) => {
             if (!isCurrentDomainSession(context)) return;
-            const { activeDuelId, phase, isDuelStartFenced } = context.getState().duelSession;
+            const { activeDuelId, phase, duelStartFenceExpiresAt } = context.getState().duelSession;
+            const isDuelStartFenced =
+                duelStartFenceExpiresAt !== null && duelStartFenceExpiresAt > Date.now();
+
+            if (duelStartFenceExpiresAt !== null && !isDuelStartFenced) {
+                context.dispatch(clearDuelStartFence());
+            }
 
             context.dispatch(
                 duelApiSlice.util.invalidateTags([{ type: "Duel", id: payload.duel_id }]),
@@ -65,7 +72,7 @@ export const createDuelHandlers = (context: DomainEventContext): RealtimeEventHa
             const { phase, searchInvitationType } = context.getState().duelSession;
             if (phase !== "searching") return;
 
-            context.dispatch(resetDuelSession());
+            context.dispatch(resetDuelSession({ fenceDuelStart: true }));
             if (searchInvitationType === "Friendly") return;
             context.dispatch(setDuelCanceledOpponentNickname(payload.opponent_nickname ?? null));
             context.dispatch(setDuelCanceled(true));

--- a/src/features/duel-session/api/realtime/domain/duelHandlers.ts
+++ b/src/features/duel-session/api/realtime/domain/duelHandlers.ts
@@ -25,7 +25,7 @@ export const createDuelHandlers = (context: DomainEventContext): RealtimeEventHa
     DuelStarted: [
         ({ payload }) => {
             if (!isCurrentDomainSession(context)) return;
-            const activeDuelId = context.getState().duelSession.activeDuelId;
+            const { activeDuelId, phase } = context.getState().duelSession;
 
             context.dispatch(
                 duelApiSlice.util.invalidateTags([{ type: "Duel", id: payload.duel_id }]),
@@ -35,6 +35,8 @@ export const createDuelHandlers = (context: DomainEventContext): RealtimeEventHa
                 context.reconcile();
                 return;
             }
+
+            if (phase !== "searching") return;
 
             context.dispatch(setActiveDuel({ duelId: payload.duel_id, userId: context.userId }));
         },
@@ -60,9 +62,11 @@ export const createDuelHandlers = (context: DomainEventContext): RealtimeEventHa
     DuelCanceled: [
         ({ payload }) => {
             if (!isCurrentDomainSession(context)) return;
-            if (context.getState().duelSession.phase !== "searching") return;
+            const { phase, searchInvitationType } = context.getState().duelSession;
+            if (phase !== "searching") return;
 
             context.dispatch(resetDuelSession());
+            if (searchInvitationType === "Friendly") return;
             context.dispatch(setDuelCanceledOpponentNickname(payload.opponent_nickname ?? null));
             context.dispatch(setDuelCanceled(true));
         },

--- a/src/features/duel-session/api/realtime/domain/duelHandlers.ts
+++ b/src/features/duel-session/api/realtime/domain/duelHandlers.ts
@@ -25,7 +25,7 @@ export const createDuelHandlers = (context: DomainEventContext): RealtimeEventHa
     DuelStarted: [
         ({ payload }) => {
             if (!isCurrentDomainSession(context)) return;
-            const { activeDuelId, phase } = context.getState().duelSession;
+            const { activeDuelId, phase, isDuelStartFenced } = context.getState().duelSession;
 
             context.dispatch(
                 duelApiSlice.util.invalidateTags([{ type: "Duel", id: payload.duel_id }]),
@@ -36,7 +36,7 @@ export const createDuelHandlers = (context: DomainEventContext): RealtimeEventHa
                 return;
             }
 
-            if (phase !== "searching") return;
+            if (phase !== "searching" && (phase !== "idle" || isDuelStartFenced)) return;
 
             context.dispatch(setActiveDuel({ duelId: payload.duel_id, userId: context.userId }));
         },

--- a/src/features/duel-session/api/realtime/domain/invitationHandlers.ts
+++ b/src/features/duel-session/api/realtime/domain/invitationHandlers.ts
@@ -40,7 +40,10 @@ export const createInvitationHandlers = (context: DomainEventContext): RealtimeE
             invalidateInvitations(context);
             if (!matchesPendingInvitation(payload, context.getState(), "direct")) return;
 
+            const isFriendlyDuel =
+                context.getState().duelSession.searchInvitationType === "Friendly";
             context.dispatch(setPhase("idle"));
+            if (isFriendlyDuel) return;
             context.dispatch(setDuelCanceledOpponentNickname(payload.opponent_nickname ?? null));
             context.dispatch(setDuelCanceled(true));
         },

--- a/src/features/duel-session/index.ts
+++ b/src/features/duel-session/index.ts
@@ -9,6 +9,7 @@ export { DuelInfo } from "./ui/DuelInfo/DuelInfo";
 
 export {
     resetDuelSession,
+    setDuelCanceled,
     setPhase,
     acknowledgeDuelResult,
     finishActiveDuel,

--- a/src/features/duel-session/model/duelSessionSlice.test.ts
+++ b/src/features/duel-session/model/duelSessionSlice.test.ts
@@ -5,6 +5,7 @@ import reducer, {
     finishActiveDuel,
     resetDuelSession,
     setActiveDuel,
+    setPhase,
 } from "./duelSessionSlice";
 
 vi.mock("entities/duel", () => ({
@@ -122,5 +123,15 @@ describe("duel result notification state", () => {
 
         state = reducer(state, setActiveDuel({ duelId: 43, userId: 7 }));
         expect(state.pendingResult).toBeNull();
+    });
+
+    it("fences a late start after cancellation without fencing a new search", () => {
+        let state = reducer(undefined, setPhase("searching"));
+        state = reducer(state, setPhase("idle"));
+
+        expect(state.isDuelStartFenced).toBe(true);
+
+        state = reducer(state, setPhase("searching"));
+        expect(state.isDuelStartFenced).toBe(false);
     });
 });

--- a/src/features/duel-session/model/duelSessionSlice.test.ts
+++ b/src/features/duel-session/model/duelSessionSlice.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import reducer, {
+    DUEL_START_FENCE_DURATION_MS,
     acknowledgeDuelResult,
     finishActiveDuel,
     resetDuelSession,
@@ -125,13 +126,25 @@ describe("duel result notification state", () => {
         expect(state.pendingResult).toBeNull();
     });
 
-    it("fences a late start after cancellation without fencing a new search", () => {
+    it("fences a late start after cancellation for a bounded interval", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-08-02T13:00:00Z"));
         let state = reducer(undefined, setPhase("searching"));
         state = reducer(state, setPhase("idle"));
 
-        expect(state.isDuelStartFenced).toBe(true);
+        expect(state.duelStartFenceExpiresAt).toBe(Date.now() + DUEL_START_FENCE_DURATION_MS);
 
         state = reducer(state, setPhase("searching"));
-        expect(state.isDuelStartFenced).toBe(false);
+        expect(state.duelStartFenceExpiresAt).toBeNull();
+        vi.useRealTimers();
+    });
+
+    it("adds the same bounded fence when a server cancellation resets the session", () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-08-02T13:00:00Z"));
+        const state = reducer(undefined, resetDuelSession({ fenceDuelStart: true }));
+
+        expect(state.duelStartFenceExpiresAt).toBe(Date.now() + DUEL_START_FENCE_DURATION_MS);
+        vi.useRealTimers();
     });
 });

--- a/src/features/duel-session/model/duelSessionSlice.ts
+++ b/src/features/duel-session/model/duelSessionSlice.ts
@@ -5,6 +5,8 @@ import type { PendingDuelType } from "entities/duel-invitation";
 import { shouldClearSessionAfterActiveDuelNotFound } from "./sessionFreshness";
 import { DuelSessionState, DuelSessionPhase } from "./types";
 
+export const DUEL_START_FENCE_DURATION_MS = 5_000;
+
 const isNotFoundError = (error: unknown) =>
     typeof error === "object" &&
     error !== null &&
@@ -16,7 +18,7 @@ const initialState: DuelSessionState = {
     activeDuelUserId: null,
     phase: "idle",
     pendingStartedInCurrentRuntime: false,
-    isDuelStartFenced: false,
+    duelStartFenceExpiresAt: null,
     lastEventId: null,
     searchNickname: null,
     searchConfigurationId: null,
@@ -36,7 +38,7 @@ const clearDuelSession = (state: DuelSessionState) => {
     state.activeDuelUserId = null;
     state.phase = "idle";
     state.pendingStartedInCurrentRuntime = false;
-    state.isDuelStartFenced = false;
+    state.duelStartFenceExpiresAt = null;
     state.lastEventId = null;
     state.searchNickname = null;
     state.searchConfigurationId = null;
@@ -56,7 +58,7 @@ const clearActiveDuel = (state: DuelSessionState) => {
     state.activeDuelUserId = null;
     state.phase = "idle";
     state.pendingStartedInCurrentRuntime = false;
-    state.isDuelStartFenced = false;
+    state.duelStartFenceExpiresAt = null;
     state.lastEventId = null;
     state.searchNickname = null;
     state.searchConfigurationId = null;
@@ -95,6 +97,10 @@ const getOpenedTaskKeys = (
         .filter((key) => (previousTasks[key] ?? null) === null && nextTasks[key]?.id !== null)
         .sort((a, b) => a.localeCompare(b));
 
+const fenceDuelStart = (state: DuelSessionState) => {
+    state.duelStartFenceExpiresAt = Date.now() + DUEL_START_FENCE_DURATION_MS;
+};
+
 const duelSessionSlice = createSlice({
     name: "duelSession",
     initialState,
@@ -107,11 +113,11 @@ const duelSessionSlice = createSlice({
             state.phase = action.payload;
             state.pendingStartedInCurrentRuntime = action.payload === "searching";
             if (action.payload === "searching") {
-                state.isDuelStartFenced = false;
+                state.duelStartFenceExpiresAt = null;
             }
             if (action.payload === "idle") {
                 if (wasSearching) {
-                    state.isDuelStartFenced = true;
+                    fenceDuelStart(state);
                 }
                 state.activeDuelId = null;
                 state.activeDuelUserId = null;
@@ -160,7 +166,7 @@ const duelSessionSlice = createSlice({
             state.activeDuelUserId = action.payload?.userId ?? null;
             if (duelId !== null) {
                 state.pendingStartedInCurrentRuntime = false;
-                state.isDuelStartFenced = false;
+                state.duelStartFenceExpiresAt = null;
                 if (state.phase === "searching" || state.phase === "idle") {
                     state.phase = "active";
                 }
@@ -217,8 +223,14 @@ const duelSessionSlice = createSlice({
         setSearchTournamentId: (state, action: PayloadAction<number | null>) => {
             state.searchTournamentId = action.payload;
         },
-        resetDuelSession: (state) => {
+        clearDuelStartFence: (state) => {
+            state.duelStartFenceExpiresAt = null;
+        },
+        resetDuelSession: (state, action: PayloadAction<{ fenceDuelStart?: boolean } | undefined>) => {
             clearDuelSession(state);
+            if (action.payload?.fenceDuelStart) {
+                fenceDuelStart(state);
+            }
         },
     },
     extraReducers: (builder) => {
@@ -283,6 +295,7 @@ export const {
     setSearchInvitationType,
     setSearchTournamentId,
     setSessionInterrupted,
+    clearDuelStartFence,
     resetDuelSession,
 } = duelSessionSlice.actions;
 export default duelSessionSlice.reducer;

--- a/src/features/duel-session/model/duelSessionSlice.ts
+++ b/src/features/duel-session/model/duelSessionSlice.ts
@@ -16,6 +16,7 @@ const initialState: DuelSessionState = {
     activeDuelUserId: null,
     phase: "idle",
     pendingStartedInCurrentRuntime: false,
+    isDuelStartFenced: false,
     lastEventId: null,
     searchNickname: null,
     searchConfigurationId: null,
@@ -35,6 +36,7 @@ const clearDuelSession = (state: DuelSessionState) => {
     state.activeDuelUserId = null;
     state.phase = "idle";
     state.pendingStartedInCurrentRuntime = false;
+    state.isDuelStartFenced = false;
     state.lastEventId = null;
     state.searchNickname = null;
     state.searchConfigurationId = null;
@@ -54,6 +56,7 @@ const clearActiveDuel = (state: DuelSessionState) => {
     state.activeDuelUserId = null;
     state.phase = "idle";
     state.pendingStartedInCurrentRuntime = false;
+    state.isDuelStartFenced = false;
     state.lastEventId = null;
     state.searchNickname = null;
     state.searchConfigurationId = null;
@@ -100,9 +103,16 @@ const duelSessionSlice = createSlice({
             if (action.payload === "searching" && state.activeDuelId !== null) {
                 return;
             }
+            const wasSearching = state.phase === "searching";
             state.phase = action.payload;
             state.pendingStartedInCurrentRuntime = action.payload === "searching";
+            if (action.payload === "searching") {
+                state.isDuelStartFenced = false;
+            }
             if (action.payload === "idle") {
+                if (wasSearching) {
+                    state.isDuelStartFenced = true;
+                }
                 state.activeDuelId = null;
                 state.activeDuelUserId = null;
                 state.searchNickname = null;
@@ -150,6 +160,7 @@ const duelSessionSlice = createSlice({
             state.activeDuelUserId = action.payload?.userId ?? null;
             if (duelId !== null) {
                 state.pendingStartedInCurrentRuntime = false;
+                state.isDuelStartFenced = false;
                 if (state.phase === "searching" || state.phase === "idle") {
                     state.phase = "active";
                 }

--- a/src/features/duel-session/model/types.ts
+++ b/src/features/duel-session/model/types.ts
@@ -14,6 +14,7 @@ export interface DuelSessionState {
     activeDuelUserId: number | null;
     phase: DuelSessionPhase;
     pendingStartedInCurrentRuntime: boolean;
+    isDuelStartFenced: boolean;
     lastEventId: string | null;
     searchNickname: string | null;
     searchConfigurationId: number | null;

--- a/src/features/duel-session/model/types.ts
+++ b/src/features/duel-session/model/types.ts
@@ -14,7 +14,7 @@ export interface DuelSessionState {
     activeDuelUserId: number | null;
     phase: DuelSessionPhase;
     pendingStartedInCurrentRuntime: boolean;
-    isDuelStartFenced: boolean;
+    duelStartFenceExpiresAt: number | null;
     lastEventId: string | null;
     searchNickname: string | null;
     searchConfigurationId: number | null;

--- a/src/pages/home/ui/HomePage.tsx
+++ b/src/pages/home/ui/HomePage.tsx
@@ -1,13 +1,10 @@
-﻿import { useEffect, useRef, useState, type FormEvent } from "react";
+﻿import { useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 
-import type { DuelConfiguration } from "entities/duel-configuration";
-import { useGetDuelConfigurationsQuery } from "entities/duel-configuration";
 import {
     useAcceptDuelInvitationMutation,
     useAcceptGroupDuelInvitationMutation,
     useAcceptTournamentDuelInvitationMutation,
-    useCreateDuelInvitationMutation,
     useDenyDuelInvitationMutation,
     useGetDuelInvitationsQuery,
 } from "entities/duel-invitation";
@@ -18,34 +15,28 @@ import {
 } from "entities/group-invitation";
 import { roleLabels } from "entities/group";
 import { selectCurrentUser } from "entities/user";
-import { DuelConfigurationManager, DuelConfigurationPicker } from "features/duel-configuration";
 import {
     DuelSessionButton,
     selectDuelSession,
-    useStartDuelSearchMutation,
-} from "features/duel-session";
-import {
     setDuelCanceled,
     setPhase,
     setSearchConfigurationId,
     setSearchInvitationType,
     setSearchNickname,
     setSearchTournamentId,
-} from "features/duel-session/model/duelSessionSlice";
+    useStartDuelSearchMutation,
+} from "features/duel-session";
+import {
+    FriendlyDuelFlow,
+    FriendlyDuelPendingButton,
+    openFriendlyDuel,
+    selectFriendlyDuel,
+} from "widgets/friendly-duel";
 import CrossIcon from "shared/assets/icons/cross.svg?react";
 import { useAppDispatch, useAppSelector } from "shared/lib/storeHooks";
 import { useSessionStorage } from "shared/lib/useSessionStorage";
-import {
-    Button,
-    IconButton,
-    InputField,
-    MainCard,
-    Modal,
-    SearchLoader,
-    StatusCard,
-} from "shared/ui";
+import { Button, IconButton, MainCard, Modal, SearchLoader } from "shared/ui";
 
-import configStyles from "features/duel-configuration/ui/DuelConfigurationManager.module.scss";
 import styles from "./HomePage.module.scss";
 
 interface IdleStateContentProps {
@@ -87,40 +78,14 @@ const HomePage = () => {
         duelCanceledOpponentNickname,
         searchInvitationType,
     } = useAppSelector(selectDuelSession);
+    const friendlyDuel = useAppSelector(selectFriendlyDuel);
     const dispatch = useAppDispatch();
     const navigate = useNavigate();
     const [showStartPanel, setShowStartPanel] = useSessionStorage("home.showStartPanel", false);
-    const [showConfigPicker, setShowConfigPicker] = useSessionStorage(
-        "home.showConfigPicker",
-        false,
-    );
-    const [showConfigCreateModal, setShowConfigCreateModal] = useSessionStorage(
-        "home.showConfigCreateModal",
-        false,
-    );
-    const [editConfig, setEditConfig] = useState<DuelConfiguration | null>(null);
-    const [showFriendlyForm, setShowFriendlyForm] = useSessionStorage(
-        "home.showFriendlyForm",
-        false,
-    );
-    const [friendlyNickname, setFriendlyNickname] = useSessionStorage("home.friendlyNickname", "");
-    const [selectedConfigId, setSelectedConfigId] = useSessionStorage<number | null>(
-        "home.selectedConfigId",
-        null,
-    );
-    const [selectedDefaultConfig, setSelectedDefaultConfig] = useSessionStorage(
-        "home.selectedDefaultConfig",
-        true,
-    );
     const [pendingInvitationNickname, setPendingInvitationNickname] = useSessionStorage<
         string | null
     >("home.pendingInvitationNickname", null);
     const [waitingForStart, setWaitingForStart] = useSessionStorage("home.waitingForStart", false);
-    const [inviteError, setInviteError] = useState<{ title: string; description?: string } | null>(
-        null,
-    );
-    const [inviteErrorClosing, setInviteErrorClosing] = useState(false);
-    const { data: configs } = useGetDuelConfigurationsQuery();
     const { data: directDuelInvitations } = useGetDuelInvitationsQuery("Ranked", {
         skip: !user,
     });
@@ -131,7 +96,6 @@ const HomePage = () => {
         skip: !user,
     });
     const [loadGroupInvitations, { data: groupInvitations }] = useLazyGetGroupInvitationsQuery();
-    const [createDuelInvitation] = useCreateDuelInvitationMutation();
     const [acceptDuelInvitation] = useAcceptDuelInvitationMutation();
     const [acceptGroupDuelInvitation] = useAcceptGroupDuelInvitationMutation();
     const [acceptTournamentDuelInvitation] = useAcceptTournamentDuelInvitationMutation();
@@ -148,44 +112,10 @@ const HomePage = () => {
     }, [user?.id, loadGroupInvitations]);
 
     useEffect(() => {
-        if (phase === "idle") return;
-
-        setShowStartPanel(false);
-        setShowConfigPicker(false);
-        setShowConfigCreateModal(false);
-        setShowFriendlyForm(false);
-        setFriendlyNickname("");
-        setSelectedConfigId(null);
-        setSelectedDefaultConfig(true);
-        setEditConfig(null);
-    }, [phase]);
-
-    useEffect(() => {
-        if (!inviteError) {
-            setInviteErrorClosing(false);
-            return;
-        }
-
-        const closingTimeout = setTimeout(() => {
-            setInviteErrorClosing(true);
-        }, 2700);
-
-        const clearTimeoutId = setTimeout(() => {
-            setInviteError(null);
-            setInviteErrorClosing(false);
-        }, 3000);
-
-        return () => {
-            clearTimeout(closingTimeout);
-            clearTimeout(clearTimeoutId);
-        };
-    }, [inviteError]);
-
-    useEffect(() => {
         if (phase !== "searching") {
             setWaitingForStart(false);
         }
-    }, [phase]);
+    }, [phase, setWaitingForStart]);
 
     const prevPhaseRef = useRef(phase);
 
@@ -223,20 +153,10 @@ const HomePage = () => {
 
     const handleStartPanelToggle = () => {
         setShowStartPanel((prev) => !prev);
-        if (showStartPanel) {
-            setShowConfigPicker(false);
-            setShowConfigCreateModal(false);
-            setShowFriendlyForm(false);
-            setFriendlyNickname("");
-            setSelectedConfigId(null);
-            setSelectedDefaultConfig(true);
-            setEditConfig(null);
-        }
     };
 
     const handleStartPanelClose = () => {
         setShowStartPanel(false);
-        setSelectedConfigId(null);
     };
 
     const handleQuickSearch = async () => {
@@ -254,129 +174,11 @@ const HomePage = () => {
         dispatch(setPhase("searching"));
         setWaitingForStart(false);
         setShowStartPanel(false);
-        setShowConfigPicker(false);
-        setShowConfigCreateModal(false);
-        setShowFriendlyForm(false);
-        setSelectedDefaultConfig(true);
-        setEditConfig(null);
     };
 
     const handleFriendlyOpen = () => {
         setShowStartPanel(false);
-        setShowConfigPicker(true);
-    };
-
-    const handleConfigBack = () => {
-        setShowConfigPicker(false);
-        setSelectedConfigId(null);
-        dispatch(setSearchConfigurationId(null));
-        dispatch(setSearchInvitationType(null));
-        dispatch(setSearchTournamentId(null));
-        setSelectedDefaultConfig(true);
-        setShowStartPanel(true);
-    };
-
-    const handleConfigClose = () => {
-        setShowConfigPicker(false);
-        setSelectedConfigId(null);
-        dispatch(setSearchConfigurationId(null));
-        dispatch(setSearchInvitationType(null));
-        dispatch(setSearchTournamentId(null));
-        setSelectedDefaultConfig(true);
-    };
-
-    const handleConfigNext = () => {
-        if (selectedDefaultConfig) {
-            dispatch(setSearchConfigurationId(null));
-        } else if (selectedConfigId) {
-            dispatch(setSearchConfigurationId(selectedConfigId));
-        } else {
-            return;
-        }
-        setShowConfigPicker(false);
-        setShowFriendlyForm(true);
-    };
-
-    const handleConfigCreate = () => {
-        setShowConfigCreateModal(true);
-    };
-
-    const handleConfigCreateClose = () => {
-        setShowConfigCreateModal(false);
-        setEditConfig(null);
-    };
-
-    const handleFriendlyCancel = () => {
-        setShowFriendlyForm(false);
-        setShowConfigPicker(true);
-        setFriendlyNickname("");
-        dispatch(setSearchNickname(null));
-        dispatch(setSearchInvitationType(null));
-        dispatch(setSearchTournamentId(null));
-    };
-
-    const handleFriendlyClose = () => {
-        setShowFriendlyForm(false);
-        setFriendlyNickname("");
-        setSelectedConfigId(null);
-        setSelectedDefaultConfig(true);
-        dispatch(setSearchNickname(null));
-        dispatch(setSearchConfigurationId(null));
-        dispatch(setSearchInvitationType(null));
-        dispatch(setSearchTournamentId(null));
-        setEditConfig(null);
-    };
-
-    const handleFriendlySubmit = async (event: FormEvent<HTMLFormElement>) => {
-        event.preventDefault();
-
-        const trimmedNickname = friendlyNickname.trim();
-        if (!trimmedNickname) return;
-        if (user?.nickname && trimmedNickname.toLowerCase() === user.nickname.toLowerCase()) {
-            setInviteError({
-                title: "Нельзя вызвать себя на дуэль",
-                description: "Укажите никнейм другого пользователя.",
-            });
-            setInviteErrorClosing(false);
-            return;
-        }
-
-        const configurationId = selectedDefaultConfig ? null : selectedConfigId;
-
-        try {
-            setInviteError(null);
-            await createDuelInvitation({
-                opponent_nickname: trimmedNickname,
-                configuration_id: configurationId ?? undefined,
-            }).unwrap();
-        } catch (error) {
-            if (
-                error &&
-                typeof error === "object" &&
-                "status" in error &&
-                (error as { status?: number }).status === 409
-            ) {
-                setInviteError({
-                    title: "Не получилось отправить вызов на дуэль",
-                    description: "Возможно, у вас уже есть вызов на дуэль от этого пользователя.",
-                });
-                setInviteErrorClosing(false);
-                return;
-            }
-            return;
-        }
-
-        dispatch(setSearchNickname(trimmedNickname));
-        dispatch(setSearchConfigurationId(configurationId ?? null));
-        dispatch(setSearchInvitationType("Friendly"));
-        dispatch(setSearchTournamentId(null));
-        dispatch(setPhase("searching"));
-        setWaitingForStart(false);
-        setShowStartPanel(false);
-        setShowConfigPicker(false);
-        setShowConfigCreateModal(false);
-        setShowFriendlyForm(false);
-        setEditConfig(null);
+        dispatch(openFriendlyDuel());
     };
 
     const handleDuelCanceledClose = () => {
@@ -459,31 +261,21 @@ const HomePage = () => {
 
     return (
         <div className={styles.homePage}>
-            {inviteError && (
-                <StatusCard
-                    variant="error"
-                    title={inviteError.title}
-                    description={inviteError.description}
-                    className={styles.statusBanner}
-                    closing={inviteErrorClosing}
-                    onClose={() => {
-                        setInviteErrorClosing(true);
-                        setTimeout(() => {
-                            setInviteError(null);
-                            setInviteErrorClosing(false);
-                        }, 200);
-                    }}
-                />
-            )}
             <div className={styles.homeContent}>
                 <MainCard className={styles.homeCard}>
-                    {phase === "searching" ? (
+                    {friendlyDuel.status === "pending" ? (
+                        <SearchingStateContent label="Ожидание ответа соперника" />
+                    ) : phase === "searching" ? (
                         <SearchingStateContent label={searchingLabel} />
                     ) : (
                         <IdleStateContent nickname={user?.nickname ?? "Аноним"} />
                     )}
 
-                    {phase === "searching" || phase === "active" ? (
+                    {friendlyDuel.status === "pending" ? (
+                        <div className={styles.duelAction}>
+                            <FriendlyDuelPendingButton />
+                        </div>
+                    ) : phase === "searching" || phase === "active" ? (
                         <div className={styles.duelAction}>
                             <DuelSessionButton />
                         </div>
@@ -522,206 +314,7 @@ const HomePage = () => {
                         </div>
                     )}
 
-                    {showConfigPicker && (
-                        <div className={styles.startOverlay}>
-                            <div
-                                className={styles.configPickerPanel}
-                                onClick={(event) => event.stopPropagation()}
-                            >
-                                <IconButton
-                                    className={styles.closeIconButton}
-                                    onClick={handleConfigClose}
-                                    aria-label="Закрыть"
-                                    size="small"
-                                >
-                                    <CrossIcon />
-                                </IconButton>
-                                <DuelConfigurationPicker
-                                    className={configStyles.cardFlat}
-                                    selectedId={selectedConfigId}
-                                    selectedIsDefault={selectedDefaultConfig}
-                                    onSelect={(id) => {
-                                        setSelectedConfigId(id);
-                                        setSelectedDefaultConfig(false);
-                                    }}
-                                    onSelectDefault={() => {
-                                        setSelectedConfigId(null);
-                                        setSelectedDefaultConfig(true);
-                                    }}
-                                    onClearSelection={() => {
-                                        setSelectedConfigId(null);
-                                        setSelectedDefaultConfig(true);
-                                    }}
-                                    onCreate={handleConfigCreate}
-                                    onEdit={(config) => {
-                                        setEditConfig(config);
-                                        setShowConfigCreateModal(true);
-                                    }}
-                                />
-                                <div className={styles.configPickerActions}>
-                                    <Button variant="outlined" onClick={handleConfigBack}>
-                                        Назад
-                                    </Button>
-                                    <Button
-                                        onClick={handleConfigNext}
-                                        disabled={!selectedDefaultConfig && !selectedConfigId}
-                                    >
-                                        Далее
-                                    </Button>
-                                </div>
-                            </div>
-                        </div>
-                    )}
-
-                    {showConfigCreateModal && (
-                        <DuelConfigurationManager
-                            mode="modalOnly"
-                            forceFormOpen={showConfigCreateModal}
-                            onForceFormClose={handleConfigCreateClose}
-                            editConfig={editConfig}
-                            onCreated={(config) => {
-                                setSelectedConfigId(config.id);
-                                setSelectedDefaultConfig(false);
-                                setShowConfigPicker(true);
-                                setEditConfig(null);
-                            }}
-                        />
-                    )}
-
-                    {showFriendlyForm && (
-                        <div className={styles.startOverlay}>
-                            <div
-                                className={styles.startPanel}
-                                onClick={(event) => event.stopPropagation()}
-                            >
-                                <IconButton
-                                    className={styles.closeIconButton}
-                                    onClick={handleFriendlyClose}
-                                    aria-label="Закрыть"
-                                    size="small"
-                                >
-                                    <CrossIcon />
-                                </IconButton>
-                                <div className={styles.friendlyHeading}>
-                                    <h2>Дружеская дуэль</h2>
-                                </div>
-                                <div className={styles.selectedConfig}>
-                                    {selectedDefaultConfig || !selectedConfigId || !configs ? (
-                                        <div className={configStyles.configItem}>
-                                            <div
-                                                className={`${configStyles.configSummary} ${styles.selectedConfigSummary}`}
-                                            >
-                                                <div className={configStyles.configTitle}>
-                                                    Стандартные правила
-                                                </div>
-                                                <div className={configStyles.configMeta}>
-                                                    Длительность: 30 минут
-                                                </div>
-                                                <div className={configStyles.configMeta}>
-                                                    Показывать код соперника во время дуэли.
-                                                </div>
-                                                <div className={configStyles.configMeta}>
-                                                    Одна задача.
-                                                </div>
-                                                <div className={configStyles.taskSummary}>
-                                                    <div>Уровень определяется автоматически.</div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    ) : (
-                                        (() => {
-                                            const selected = configs.find(
-                                                (config) => config.id === selectedConfigId,
-                                            );
-                                            if (!selected) {
-                                                return null;
-                                            }
-                                            const tasksEntries = Object.entries(
-                                                selected.tasks ?? {},
-                                            ).sort(
-                                                ([leftKey], [rightKey]) =>
-                                                    Number(leftKey) - Number(rightKey),
-                                            );
-                                            const taskSummary = tasksEntries.map(
-                                                ([, task], index) => {
-                                                    const taskKey = String.fromCharCode(65 + index);
-                                                    const topics =
-                                                        task.topics && task.topics.length > 0
-                                                            ? ` | ${task.topics.join(", ")}`
-                                                            : "";
-                                                    return `${taskKey}: уровень ${task.level}${topics}`;
-                                                },
-                                            );
-                                            const orderLabel =
-                                                selected.task_order === "Sequential"
-                                                    ? "Задачи открываются одна за другой."
-                                                    : "Все задачи доступны сразу.";
-                                            return (
-                                                <div className={configStyles.configItem}>
-                                                    <div
-                                                        className={`${configStyles.configSummary} ${styles.selectedConfigSummary}`}
-                                                    >
-                                                        <div className={configStyles.configMeta}>
-                                                            Длительность:{" "}
-                                                            {selected.max_duration_minutes} мин
-                                                        </div>
-                                                        <div className={configStyles.configMeta}>
-                                                            {selected.should_show_opponent_solution
-                                                                ? "Показывать код соперника во время дуэли."
-                                                                : "Не показывать код соперника во время дуэли."}
-                                                        </div>
-                                                        <div className={configStyles.configMeta}>
-                                                            {orderLabel}
-                                                        </div>
-                                                        {taskSummary.length > 0 && (
-                                                            <div
-                                                                className={configStyles.taskSummary}
-                                                            >
-                                                                {taskSummary.map((item) => (
-                                                                    <div key={item}>{item}</div>
-                                                                ))}
-                                                            </div>
-                                                        )}
-                                                    </div>
-                                                </div>
-                                            );
-                                        })()
-                                    )}
-                                </div>
-                                <p className={styles.friendlyDescription}>Укажите ник соперника.</p>
-                                <form
-                                    className={styles.friendlyForm}
-                                    onSubmit={handleFriendlySubmit}
-                                >
-                                    <InputField
-                                        id="friendly-duel-nickname"
-                                        labelValue="Никнейм оппонента"
-                                        wrapperClassName={styles.friendlyInputField}
-                                        labelClassName={styles.friendlyInputLabelHidden}
-                                        inputClassName={styles.friendlyInput}
-                                        placeholder="Никнейм"
-                                        value={friendlyNickname}
-                                        onChange={(event) =>
-                                            setFriendlyNickname(event.target.value)
-                                        }
-                                        autoComplete="off"
-                                    />
-                                    <div className={styles.friendlyButtons}>
-                                        <Button variant="outlined" onClick={handleFriendlyCancel}>
-                                            Назад
-                                        </Button>
-                                        <Button
-                                            type="submit"
-                                            className={styles.friendlySubmit}
-                                            disabled={!friendlyNickname.trim()}
-                                        >
-                                            Вызов
-                                        </Button>
-                                    </div>
-                                </form>
-                            </div>
-                        </div>
-                    )}
+                    <FriendlyDuelFlow />
                 </MainCard>
                 {(visibleInvitations.length > 0 || visibleGroupInvitations.length > 0) &&
                     phase !== "active" && (

--- a/src/widgets/friendly-duel/index.ts
+++ b/src/widgets/friendly-duel/index.ts
@@ -1,0 +1,9 @@
+export { default as friendlyDuelReducer } from "./model/friendlyDuelSlice";
+export { selectFriendlyDuel } from "./model/selectors";
+export {
+    closeFriendlyDuel,
+    openFriendlyDuel,
+    returnToFriendlyDuelConfiguration,
+} from "./model/friendlyDuelSlice";
+export { FriendlyDuelFlow } from "./ui/FriendlyDuelFlow";
+export { FriendlyDuelPendingButton } from "./ui/FriendlyDuelPendingButton";

--- a/src/widgets/friendly-duel/model/configurationScenario.ts
+++ b/src/widgets/friendly-duel/model/configurationScenario.ts
@@ -1,0 +1,4 @@
+import type { FriendlyDuelState } from "./types";
+
+export const isFriendlyDuelConfigurationScenarioActive = (state: FriendlyDuelState) =>
+    state.status === "configuring";

--- a/src/widgets/friendly-duel/model/creationError.test.ts
+++ b/src/widgets/friendly-duel/model/creationError.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+import { getFriendlyDuelCreationError } from "./creationError";
+
+describe("friendly duel creation errors", () => {
+    it("explains that the opponent nickname was not found for a 404 response", () => {
+        expect(getFriendlyDuelCreationError({ status: 404 })).toEqual({
+            title: "Не получилось отправить вызов на дуэль",
+            description: "Не найден соперник с таким никнеймом",
+        });
+    });
+});

--- a/src/widgets/friendly-duel/model/creationError.ts
+++ b/src/widgets/friendly-duel/model/creationError.ts
@@ -1,0 +1,30 @@
+import type { FriendlyDuelError } from "./types";
+
+const getErrorStatus = (error: unknown) => {
+    if (!error || typeof error !== "object" || !("status" in error)) return null;
+
+    return (error as { status?: number }).status ?? null;
+};
+
+export const getFriendlyDuelCreationError = (error: unknown): FriendlyDuelError => {
+    const status = getErrorStatus(error);
+
+    if (status === 404) {
+        return {
+            title: "Не получилось отправить вызов на дуэль",
+            description: "Не найден соперник с таким никнеймом",
+        };
+    }
+
+    if (status === 409) {
+        return {
+            title: "Не получилось отправить вызов на дуэль",
+            description: "Возможно, у вас уже есть вызов на дуэль от этого пользователя.",
+        };
+    }
+
+    return {
+        title: "Не получилось отправить вызов на дуэль",
+        description: "Проверьте соединение и попробуйте ещё раз.",
+    };
+};

--- a/src/widgets/friendly-duel/model/friendlyDuelSlice.test.ts
+++ b/src/widgets/friendly-duel/model/friendlyDuelSlice.test.ts
@@ -9,6 +9,7 @@ import reducer, {
     requestFriendlyDuelCancellation,
     returnToFriendlyDuelConfiguration,
     selectFriendlyDuelConfiguration,
+    setFriendlyDuelUserId,
     setFriendlyDuelNickname,
     showFriendlyDuelOpponentStep,
 } from "./friendlyDuelSlice";
@@ -84,5 +85,26 @@ describe("friendly duel state machine", () => {
         expect(isFriendlyDuelConfigurationScenarioActive(idleState)).toBe(false);
         expect(isFriendlyDuelConfigurationScenarioActive(configuringState)).toBe(true);
         expect(isFriendlyDuelConfigurationScenarioActive(pendingState)).toBe(false);
+    });
+
+    it("clears a configured flow when the authenticated user changes or logs out", () => {
+        let state = reducer(undefined, setFriendlyDuelUserId(1));
+        state = reducer(state, openFriendlyDuel());
+        state = reducer(state, selectFriendlyDuelConfiguration(11));
+        state = reducer(state, showFriendlyDuelOpponentStep());
+        state = reducer(state, setFriendlyDuelNickname("opponent"));
+
+        state = reducer(state, setFriendlyDuelUserId(2));
+
+        expect(state).toMatchObject({
+            ownerUserId: 2,
+            status: "idle",
+            nickname: "",
+            configurationId: null,
+        });
+
+        state = reducer(state, openFriendlyDuel());
+        state = reducer(state, { type: "auth/logout" });
+        expect(state).toMatchObject({ ownerUserId: null, status: "idle", nickname: "" });
     });
 });

--- a/src/widgets/friendly-duel/model/friendlyDuelSlice.test.ts
+++ b/src/widgets/friendly-duel/model/friendlyDuelSlice.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import reducer, {
+    beginFriendlyDuelPending,
+    cancelFriendlyDuel,
+    failFriendlyDuelCancellation,
+    matchFriendlyDuel,
+    openFriendlyDuel,
+    requestFriendlyDuelCancellation,
+    returnToFriendlyDuelConfiguration,
+    selectFriendlyDuelConfiguration,
+    setFriendlyDuelNickname,
+    showFriendlyDuelOpponentStep,
+} from "./friendlyDuelSlice";
+import { isFriendlyDuelConfigurationScenarioActive } from "./configurationScenario";
+
+const createPendingState = () => {
+    let state = reducer(undefined, openFriendlyDuel());
+    state = reducer(state, selectFriendlyDuelConfiguration(11));
+    state = reducer(state, showFriendlyDuelOpponentStep());
+    state = reducer(state, setFriendlyDuelNickname("opponent"));
+    return reducer(state, beginFriendlyDuelPending());
+};
+
+describe("friendly duel state machine", () => {
+    it("moves from configuration to pending and then to matched", () => {
+        let state = createPendingState();
+        state = reducer(state, matchFriendlyDuel());
+
+        expect(state).toMatchObject({
+            status: "matched",
+            nickname: "opponent",
+            configurationId: 11,
+        });
+    });
+
+    it("ignores a second cancel and a late match after a user cancellation", () => {
+        let state = createPendingState();
+        state = reducer(state, requestFriendlyDuelCancellation());
+        state = reducer(state, requestFriendlyDuelCancellation());
+        state = reducer(state, cancelFriendlyDuel("user"));
+        state = reducer(state, matchFriendlyDuel());
+
+        expect(state).toMatchObject({
+            status: "canceled",
+            cancellationReason: "user",
+            isCanceling: false,
+        });
+    });
+
+    it("keeps the selected configuration available for another attempt after cancellation", () => {
+        let state = createPendingState();
+        state = reducer(state, cancelFriendlyDuel("server"));
+        state = reducer(state, returnToFriendlyDuelConfiguration());
+
+        expect(state).toMatchObject({
+            status: "configuring",
+            step: "opponent",
+            nickname: "opponent",
+            configurationId: 11,
+        });
+    });
+
+    it("recovers from a cancellation mutation error without keeping the control disabled", () => {
+        let state = createPendingState();
+        state = reducer(state, requestFriendlyDuelCancellation());
+        state = reducer(
+            state,
+            failFriendlyDuelCancellation({ title: "Не удалось отменить вызов" }),
+        );
+
+        expect(state).toMatchObject({
+            status: "pending",
+            isCanceling: false,
+            error: { title: "Не удалось отменить вызов" },
+        });
+    });
+
+    it("loads configurations only while the configuration scenario is open", () => {
+        const idleState = reducer(undefined, { type: "test/init" });
+        const configuringState = reducer(idleState, openFriendlyDuel());
+        const pendingState = createPendingState();
+
+        expect(isFriendlyDuelConfigurationScenarioActive(idleState)).toBe(false);
+        expect(isFriendlyDuelConfigurationScenarioActive(configuringState)).toBe(true);
+        expect(isFriendlyDuelConfigurationScenarioActive(pendingState)).toBe(false);
+    });
+});

--- a/src/widgets/friendly-duel/model/friendlyDuelSlice.ts
+++ b/src/widgets/friendly-duel/model/friendlyDuelSlice.ts
@@ -3,6 +3,7 @@ import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import type { FriendlyDuelCancellationReason, FriendlyDuelError, FriendlyDuelState } from "./types";
 
 const initialState: FriendlyDuelState = {
+    ownerUserId: null,
     status: "idle",
     step: "configuration",
     nickname: "",
@@ -28,6 +29,12 @@ const friendlyDuelSlice = createSlice({
     name: "friendlyDuel",
     initialState,
     reducers: {
+        setFriendlyDuelUserId: (state, action: PayloadAction<number | null>) => {
+            if (state.ownerUserId === action.payload) return;
+
+            resetToIdle(state);
+            state.ownerUserId = action.payload;
+        },
         openFriendlyDuel: (state) => {
             resetToIdle(state);
             state.status = "configuring";
@@ -120,9 +127,16 @@ const friendlyDuelSlice = createSlice({
             state.error = null;
         },
     },
+    extraReducers: (builder) => {
+        builder.addCase("auth/logout", (state) => {
+            resetToIdle(state);
+            state.ownerUserId = null;
+        });
+    },
 });
 
 export const {
+    setFriendlyDuelUserId,
     openFriendlyDuel,
     closeFriendlyDuel,
     selectFriendlyDuelConfiguration,

--- a/src/widgets/friendly-duel/model/friendlyDuelSlice.ts
+++ b/src/widgets/friendly-duel/model/friendlyDuelSlice.ts
@@ -1,0 +1,144 @@
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+import type { FriendlyDuelCancellationReason, FriendlyDuelError, FriendlyDuelState } from "./types";
+
+const initialState: FriendlyDuelState = {
+    status: "idle",
+    step: "configuration",
+    nickname: "",
+    configurationId: null,
+    usesDefaultConfiguration: true,
+    isCanceling: false,
+    cancellationReason: null,
+    error: null,
+};
+
+const resetToIdle = (state: FriendlyDuelState) => {
+    state.status = "idle";
+    state.step = "configuration";
+    state.nickname = "";
+    state.configurationId = null;
+    state.usesDefaultConfiguration = true;
+    state.isCanceling = false;
+    state.cancellationReason = null;
+    state.error = null;
+};
+
+const friendlyDuelSlice = createSlice({
+    name: "friendlyDuel",
+    initialState,
+    reducers: {
+        openFriendlyDuel: (state) => {
+            resetToIdle(state);
+            state.status = "configuring";
+        },
+        closeFriendlyDuel: (state) => {
+            resetToIdle(state);
+        },
+        selectFriendlyDuelConfiguration: (state, action: PayloadAction<number>) => {
+            if (state.status !== "configuring") return;
+            state.configurationId = action.payload;
+            state.usesDefaultConfiguration = false;
+        },
+        selectFriendlyDuelDefaultConfiguration: (state) => {
+            if (state.status !== "configuring") return;
+            state.configurationId = null;
+            state.usesDefaultConfiguration = true;
+        },
+        showFriendlyDuelOpponentStep: (state) => {
+            if (state.status !== "configuring") return;
+            if (!state.usesDefaultConfiguration && state.configurationId === null) return;
+            state.step = "opponent";
+        },
+        showFriendlyDuelConfigurationStep: (state) => {
+            if (state.status !== "configuring") return;
+            state.step = "configuration";
+        },
+        setFriendlyDuelNickname: (state, action: PayloadAction<string>) => {
+            if (state.status !== "configuring") return;
+            state.nickname = action.payload;
+        },
+        beginFriendlyDuelPending: (state) => {
+            if (state.status !== "configuring" || !state.nickname.trim()) return;
+            state.status = "pending";
+            state.isCanceling = false;
+            state.cancellationReason = null;
+            state.error = null;
+        },
+        restoreFriendlyDuelPending: (
+            state,
+            action: PayloadAction<{ nickname: string; configurationId: number | null }>,
+        ) => {
+            if (state.status !== "idle") return;
+            state.status = "pending";
+            state.step = "opponent";
+            state.nickname = action.payload.nickname;
+            state.configurationId = action.payload.configurationId;
+            state.usesDefaultConfiguration = action.payload.configurationId === null;
+            state.isCanceling = false;
+            state.cancellationReason = null;
+            state.error = null;
+        },
+        matchFriendlyDuel: (state) => {
+            if (state.status !== "pending") return;
+            state.status = "matched";
+            state.isCanceling = false;
+            state.error = null;
+        },
+        requestFriendlyDuelCancellation: (state) => {
+            if (state.status !== "pending" || state.isCanceling) return;
+            state.isCanceling = true;
+            state.error = null;
+        },
+        cancelFriendlyDuel: (state, action: PayloadAction<FriendlyDuelCancellationReason>) => {
+            if (state.status !== "pending") return;
+            state.status = "canceled";
+            state.isCanceling = false;
+            state.cancellationReason = action.payload;
+            state.error = null;
+        },
+        failFriendlyDuelCancellation: (state, action: PayloadAction<FriendlyDuelError>) => {
+            if (state.status !== "pending") return;
+            state.isCanceling = false;
+            state.error = action.payload;
+        },
+        failFriendlyDuelCreation: (state, action: PayloadAction<FriendlyDuelError>) => {
+            if (state.status !== "configuring" && state.status !== "pending") return;
+            state.status = "error";
+            state.isCanceling = false;
+            state.error = action.payload;
+        },
+        returnToFriendlyDuelConfiguration: (state) => {
+            if (state.status !== "canceled" && state.status !== "error") return;
+            state.status = "configuring";
+            state.step = "opponent";
+            state.isCanceling = false;
+            state.cancellationReason = null;
+            state.error = null;
+        },
+        clearFriendlyDuelError: (state) => {
+            state.error = null;
+        },
+    },
+});
+
+export const {
+    openFriendlyDuel,
+    closeFriendlyDuel,
+    selectFriendlyDuelConfiguration,
+    selectFriendlyDuelDefaultConfiguration,
+    showFriendlyDuelOpponentStep,
+    showFriendlyDuelConfigurationStep,
+    setFriendlyDuelNickname,
+    beginFriendlyDuelPending,
+    restoreFriendlyDuelPending,
+    matchFriendlyDuel,
+    requestFriendlyDuelCancellation,
+    cancelFriendlyDuel,
+    failFriendlyDuelCancellation,
+    failFriendlyDuelCreation,
+    returnToFriendlyDuelConfiguration,
+    clearFriendlyDuelError,
+} = friendlyDuelSlice.actions;
+
+export default friendlyDuelSlice.reducer;

--- a/src/widgets/friendly-duel/model/selectors.ts
+++ b/src/widgets/friendly-duel/model/selectors.ts
@@ -1,0 +1,1 @@
+export const selectFriendlyDuel = (state: RootState) => state.friendlyDuel;

--- a/src/widgets/friendly-duel/model/types.ts
+++ b/src/widgets/friendly-duel/model/types.ts
@@ -16,6 +16,7 @@ export interface FriendlyDuelError {
 }
 
 export interface FriendlyDuelState {
+    ownerUserId: number | null;
     status: FriendlyDuelStatus;
     step: FriendlyDuelConfigurationStep;
     nickname: string;

--- a/src/widgets/friendly-duel/model/types.ts
+++ b/src/widgets/friendly-duel/model/types.ts
@@ -1,0 +1,27 @@
+export type FriendlyDuelStatus =
+    | "idle"
+    | "configuring"
+    | "pending"
+    | "matched"
+    | "canceled"
+    | "error";
+
+export type FriendlyDuelConfigurationStep = "configuration" | "opponent";
+
+export type FriendlyDuelCancellationReason = "user" | "server" | "disconnect";
+
+export interface FriendlyDuelError {
+    title: string;
+    description?: string;
+}
+
+export interface FriendlyDuelState {
+    status: FriendlyDuelStatus;
+    step: FriendlyDuelConfigurationStep;
+    nickname: string;
+    configurationId: number | null;
+    usesDefaultConfiguration: boolean;
+    isCanceling: boolean;
+    cancellationReason: FriendlyDuelCancellationReason | null;
+    error: FriendlyDuelError | null;
+}

--- a/src/widgets/friendly-duel/ui/FriendlyDuelFlow.module.scss
+++ b/src/widgets/friendly-duel/ui/FriendlyDuelFlow.module.scss
@@ -1,0 +1,110 @@
+.overlay {
+    position: fixed;
+    inset: 70px 0 0;
+    z-index: 20;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background: var(--background);
+}
+
+.panel,
+.configurationPanel {
+    position: relative;
+    width: min(100%, 520px);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1em;
+    padding: 1.75em;
+    box-sizing: border-box;
+    background: var(--card-primary);
+    border-radius: 0.75em;
+    box-shadow: 0 2px 16px 0 rgba(0, 0, 0, 0.2);
+}
+
+.configurationPanel {
+    max-height: calc(100vh - 3em);
+    overflow: auto;
+}
+
+.closeIconButton {
+    position: absolute;
+    top: 0.75em;
+    right: 0.75em;
+    width: 1.75em;
+    height: 1.75em;
+    border-radius: 999px;
+    border: 1px solid color-mix(in srgb, var(--card-secondary) 60%, transparent);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+}
+
+.closeIconButton:hover {
+    color: var(--text-primary);
+    background-color: var(--card-secondary);
+    border-color: color-mix(in srgb, var(--card-secondary) 80%, transparent);
+}
+
+.configurationActions,
+.formActions,
+.resultActions {
+    display: flex;
+    width: 100%;
+    gap: 1em;
+}
+
+.configurationActions > *,
+.formActions > *,
+.resultActions > * {
+    flex: 1;
+}
+
+.heading {
+    font-size: 1.4rem;
+}
+
+.selectedConfiguration,
+.form {
+    width: min(100%, 520px);
+}
+
+.selectedConfigSummary {
+    cursor: default;
+}
+
+.description,
+.resultDescription {
+    color: var(--text-secondary);
+    text-align: center;
+}
+
+.form {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1em;
+}
+
+.inputField {
+    width: 100%;
+}
+
+.inputLabelHidden {
+    display: none;
+}
+
+.input {
+    width: 100%;
+}
+
+.pendingControl {
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+    width: 100%;
+}

--- a/src/widgets/friendly-duel/ui/FriendlyDuelFlow.module.scss
+++ b/src/widgets/friendly-duel/ui/FriendlyDuelFlow.module.scss
@@ -51,15 +51,24 @@
 }
 
 .configurationActions,
-.formActions,
-.resultActions {
+.formActions {
     display: flex;
     width: 100%;
     gap: 1em;
 }
 
 .configurationActions > *,
-.formActions > *,
+.formActions > * {
+    flex: 1;
+}
+
+.resultActions {
+    display: flex;
+    width: 100%;
+    gap: 1em;
+    margin-top: 1.5em;
+}
+
 .resultActions > * {
     flex: 1;
 }

--- a/src/widgets/friendly-duel/ui/FriendlyDuelFlow.tsx
+++ b/src/widgets/friendly-duel/ui/FriendlyDuelFlow.tsx
@@ -1,0 +1,401 @@
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import { useNavigate } from "react-router-dom";
+
+import type { DuelConfiguration } from "entities/duel-configuration";
+import { useGetDuelConfigurationsQuery } from "entities/duel-configuration";
+import { useCreateDuelInvitationMutation } from "entities/duel-invitation";
+import { DuelConfigurationManager, DuelConfigurationPicker } from "features/duel-configuration";
+import {
+    selectDuelSession,
+    setPhase,
+    setSearchConfigurationId,
+    setSearchInvitationType,
+    setSearchNickname,
+    setSearchTournamentId,
+} from "features/duel-session";
+import CrossIcon from "shared/assets/icons/cross.svg?react";
+import { useAppDispatch, useAppSelector } from "shared/lib/storeHooks";
+import { Button, IconButton, InputField, Modal } from "shared/ui";
+
+import configStyles from "features/duel-configuration/ui/DuelConfigurationManager.module.scss";
+import {
+    beginFriendlyDuelPending,
+    cancelFriendlyDuel,
+    closeFriendlyDuel,
+    failFriendlyDuelCreation,
+    matchFriendlyDuel,
+    restoreFriendlyDuelPending,
+    returnToFriendlyDuelConfiguration,
+    selectFriendlyDuelConfiguration,
+    selectFriendlyDuelDefaultConfiguration,
+    setFriendlyDuelNickname,
+    showFriendlyDuelConfigurationStep,
+    showFriendlyDuelOpponentStep,
+} from "../model/friendlyDuelSlice";
+import { isFriendlyDuelConfigurationScenarioActive } from "../model/configurationScenario";
+import { selectFriendlyDuel } from "../model/selectors";
+
+import styles from "./FriendlyDuelFlow.module.scss";
+
+const getCreationError = (error: unknown) => {
+    if (
+        error &&
+        typeof error === "object" &&
+        "status" in error &&
+        (error as { status?: number }).status === 409
+    ) {
+        return {
+            title: "Не получилось отправить вызов на дуэль",
+            description: "Возможно, у вас уже есть вызов на дуэль от этого пользователя.",
+        };
+    }
+
+    return {
+        title: "Не получилось отправить вызов на дуэль",
+        description: "Проверьте соединение и попробуйте ещё раз.",
+    };
+};
+
+const SelectedConfiguration = ({
+    configurationId,
+    usesDefaultConfiguration,
+}: {
+    configurationId: number | null;
+    usesDefaultConfiguration: boolean;
+}) => {
+    const { data: configurations } = useGetDuelConfigurationsQuery();
+    const selectedConfiguration = configurations?.find((config) => config.id === configurationId);
+
+    if (usesDefaultConfiguration || !selectedConfiguration) {
+        return (
+            <div className={configStyles.configItem}>
+                <div className={`${configStyles.configSummary} ${styles.selectedConfigSummary}`}>
+                    <div className={configStyles.configTitle}>Стандартные правила</div>
+                    <div className={configStyles.configMeta}>Длительность: 30 минут</div>
+                    <div className={configStyles.configMeta}>
+                        Показывать код соперника во время дуэли.
+                    </div>
+                    <div className={configStyles.configMeta}>Одна задача.</div>
+                    <div className={configStyles.taskSummary}>
+                        <div>Уровень определяется автоматически.</div>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    const taskSummary = Object.entries(selectedConfiguration.tasks ?? {})
+        .sort(([leftKey], [rightKey]) => Number(leftKey) - Number(rightKey))
+        .map(([, task], index) => {
+            const taskKey = String.fromCharCode(65 + index);
+            const topics = task.topics?.length ? ` | ${task.topics.join(", ")}` : "";
+            return `${taskKey}: уровень ${task.level}${topics}`;
+        });
+    const orderLabel =
+        selectedConfiguration.task_order === "Sequential"
+            ? "Задачи открываются одна за другой."
+            : "Все задачи доступны сразу.";
+
+    return (
+        <div className={configStyles.configItem}>
+            <div className={`${configStyles.configSummary} ${styles.selectedConfigSummary}`}>
+                <div className={configStyles.configMeta}>
+                    Длительность: {selectedConfiguration.max_duration_minutes} мин
+                </div>
+                <div className={configStyles.configMeta}>
+                    {selectedConfiguration.should_show_opponent_solution
+                        ? "Показывать код соперника во время дуэли."
+                        : "Не показывать код соперника во время дуэли."}
+                </div>
+                <div className={configStyles.configMeta}>{orderLabel}</div>
+                {taskSummary.length > 0 && (
+                    <div className={configStyles.taskSummary}>
+                        {taskSummary.map((item) => (
+                            <div key={item}>{item}</div>
+                        ))}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export const FriendlyDuelFlow = () => {
+    const dispatch = useAppDispatch();
+    const navigate = useNavigate();
+    const user = useAppSelector((state) => state.auth.user);
+    const friendlyDuel = useAppSelector(selectFriendlyDuel);
+    const {
+        phase,
+        activeDuelId,
+        searchNickname,
+        searchConfigurationId,
+        searchInvitationType,
+        sessionInterrupted,
+    } = useAppSelector(selectDuelSession);
+    const [createInvitation, { isLoading: isCreatingInvitation }] =
+        useCreateDuelInvitationMutation();
+    const [showConfigurationManager, setShowConfigurationManager] = useState(false);
+    const [editConfiguration, setEditConfiguration] = useState<DuelConfiguration | null>(null);
+    const sessionRef = useRef({ phase, activeDuelId });
+
+    sessionRef.current = { phase, activeDuelId };
+
+    useEffect(() => {
+        if (
+            friendlyDuel.status === "idle" &&
+            phase === "searching" &&
+            searchInvitationType === "Friendly" &&
+            searchNickname
+        ) {
+            dispatch(
+                restoreFriendlyDuelPending({
+                    nickname: searchNickname,
+                    configurationId: searchConfigurationId,
+                }),
+            );
+        }
+    }, [
+        dispatch,
+        friendlyDuel.status,
+        phase,
+        searchConfigurationId,
+        searchInvitationType,
+        searchNickname,
+    ]);
+
+    useEffect(() => {
+        if (friendlyDuel.status !== "pending") return;
+
+        if (phase === "active" && activeDuelId) {
+            dispatch(matchFriendlyDuel());
+            return;
+        }
+
+        if (phase === "idle" && !friendlyDuel.isCanceling) {
+            dispatch(cancelFriendlyDuel(sessionInterrupted ? "disconnect" : "server"));
+        }
+    }, [
+        activeDuelId,
+        dispatch,
+        friendlyDuel.isCanceling,
+        friendlyDuel.status,
+        phase,
+        sessionInterrupted,
+    ]);
+
+    useEffect(() => {
+        if (friendlyDuel.status !== "matched" || !activeDuelId) return;
+        navigate(`/duel/${activeDuelId}`);
+        dispatch(closeFriendlyDuel());
+    }, [activeDuelId, dispatch, friendlyDuel.status, navigate]);
+
+    const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+
+        const nickname = friendlyDuel.nickname.trim();
+        if (!nickname || isCreatingInvitation) return;
+        if (user?.nickname && nickname.toLowerCase() === user.nickname.toLowerCase()) {
+            dispatch(
+                failFriendlyDuelCreation({
+                    title: "Нельзя вызвать себя на дуэль",
+                    description: "Укажите никнейм другого пользователя.",
+                }),
+            );
+            return;
+        }
+
+        const configurationId = friendlyDuel.usesDefaultConfiguration
+            ? null
+            : friendlyDuel.configurationId;
+
+        dispatch(beginFriendlyDuelPending());
+        dispatch(setSearchNickname(nickname));
+        dispatch(setSearchConfigurationId(configurationId));
+        dispatch(setSearchInvitationType("Friendly"));
+        dispatch(setSearchTournamentId(null));
+        dispatch(setPhase("searching"));
+
+        try {
+            await createInvitation({
+                opponent_nickname: nickname,
+                configuration_id: configurationId ?? undefined,
+            }).unwrap();
+        } catch (error) {
+            if (sessionRef.current.phase === "active" && sessionRef.current.activeDuelId) {
+                dispatch(matchFriendlyDuel());
+                return;
+            }
+
+            dispatch(failFriendlyDuelCreation(getCreationError(error)));
+            dispatch(setPhase("idle"));
+        }
+    };
+
+    const isConfigurationScenarioActive = isFriendlyDuelConfigurationScenarioActive(friendlyDuel);
+    const cancellationDescription =
+        friendlyDuel.cancellationReason === "user"
+            ? "Поиск отменён. Выбранные правила и никнейм сохранены для повторного вызова."
+            : friendlyDuel.cancellationReason === "disconnect"
+              ? "Соединение было прервано, поэтому поиск остановлен."
+              : "Вызов больше не ожидает ответа соперника.";
+
+    return (
+        <>
+            {isConfigurationScenarioActive && friendlyDuel.step === "configuration" && (
+                <div className={styles.overlay}>
+                    <div className={styles.configurationPanel}>
+                        <IconButton
+                            className={styles.closeIconButton}
+                            onClick={() => dispatch(closeFriendlyDuel())}
+                            aria-label="Закрыть"
+                            size="small"
+                        >
+                            <CrossIcon />
+                        </IconButton>
+                        <DuelConfigurationPicker
+                            className={configStyles.cardFlat}
+                            selectedId={friendlyDuel.configurationId}
+                            selectedIsDefault={friendlyDuel.usesDefaultConfiguration}
+                            onSelect={(id) => dispatch(selectFriendlyDuelConfiguration(id))}
+                            onSelectDefault={() =>
+                                dispatch(selectFriendlyDuelDefaultConfiguration())
+                            }
+                            onClearSelection={() =>
+                                dispatch(selectFriendlyDuelDefaultConfiguration())
+                            }
+                            onCreate={() => setShowConfigurationManager(true)}
+                            onEdit={(configuration) => {
+                                setEditConfiguration(configuration);
+                                setShowConfigurationManager(true);
+                            }}
+                        />
+                        <div className={styles.configurationActions}>
+                            <Button
+                                variant="outlined"
+                                onClick={() => dispatch(closeFriendlyDuel())}
+                            >
+                                Назад
+                            </Button>
+                            <Button
+                                onClick={() => dispatch(showFriendlyDuelOpponentStep())}
+                                disabled={
+                                    !friendlyDuel.usesDefaultConfiguration &&
+                                    friendlyDuel.configurationId === null
+                                }
+                            >
+                                Далее
+                            </Button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {isConfigurationScenarioActive && friendlyDuel.step === "opponent" && (
+                <div className={styles.overlay}>
+                    <div className={styles.panel}>
+                        <IconButton
+                            className={styles.closeIconButton}
+                            onClick={() => dispatch(closeFriendlyDuel())}
+                            aria-label="Закрыть"
+                            size="small"
+                        >
+                            <CrossIcon />
+                        </IconButton>
+                        <h2 className={styles.heading}>Дружеская дуэль</h2>
+                        <div className={styles.selectedConfiguration}>
+                            <SelectedConfiguration
+                                configurationId={friendlyDuel.configurationId}
+                                usesDefaultConfiguration={friendlyDuel.usesDefaultConfiguration}
+                            />
+                        </div>
+                        <p className={styles.description}>Укажите ник соперника.</p>
+                        <form className={styles.form} onSubmit={handleSubmit}>
+                            <InputField
+                                id="friendly-duel-nickname"
+                                labelValue="Никнейм оппонента"
+                                wrapperClassName={styles.inputField}
+                                labelClassName={styles.inputLabelHidden}
+                                inputClassName={styles.input}
+                                placeholder="Никнейм"
+                                value={friendlyDuel.nickname}
+                                onChange={(event) =>
+                                    dispatch(setFriendlyDuelNickname(event.target.value))
+                                }
+                                autoComplete="off"
+                            />
+                            <div className={styles.formActions}>
+                                <Button
+                                    variant="outlined"
+                                    onClick={() => dispatch(showFriendlyDuelConfigurationStep())}
+                                    type="button"
+                                >
+                                    Назад
+                                </Button>
+                                <Button
+                                    type="submit"
+                                    disabled={!friendlyDuel.nickname.trim() || isCreatingInvitation}
+                                >
+                                    {isCreatingInvitation ? "Отправка..." : "Вызов"}
+                                </Button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
+            )}
+
+            {showConfigurationManager && (
+                <DuelConfigurationManager
+                    mode="modalOnly"
+                    forceFormOpen={showConfigurationManager}
+                    onForceFormClose={() => {
+                        setShowConfigurationManager(false);
+                        setEditConfiguration(null);
+                    }}
+                    editConfig={editConfiguration}
+                    onCreated={(configuration) => {
+                        dispatch(selectFriendlyDuelConfiguration(configuration.id));
+                        setShowConfigurationManager(false);
+                        setEditConfiguration(null);
+                    }}
+                />
+            )}
+
+            {friendlyDuel.status === "canceled" && (
+                <Modal
+                    title="Дружеский вызов отменён"
+                    onClose={() => dispatch(closeFriendlyDuel())}
+                >
+                    <p className={styles.resultDescription}>{cancellationDescription}</p>
+                    <div className={styles.resultActions}>
+                        <Button variant="outlined" onClick={() => dispatch(closeFriendlyDuel())}>
+                            Закрыть
+                        </Button>
+                        <Button onClick={() => dispatch(returnToFriendlyDuelConfiguration())}>
+                            Настроить снова
+                        </Button>
+                    </div>
+                </Modal>
+            )}
+
+            {friendlyDuel.status === "error" && friendlyDuel.error && (
+                <Modal
+                    title={friendlyDuel.error.title}
+                    onClose={() => dispatch(closeFriendlyDuel())}
+                >
+                    {friendlyDuel.error.description && (
+                        <p className={styles.resultDescription}>{friendlyDuel.error.description}</p>
+                    )}
+                    <div className={styles.resultActions}>
+                        <Button variant="outlined" onClick={() => dispatch(closeFriendlyDuel())}>
+                            Закрыть
+                        </Button>
+                        <Button onClick={() => dispatch(returnToFriendlyDuelConfiguration())}>
+                            Исправить и повторить
+                        </Button>
+                    </div>
+                </Modal>
+            )}
+        </>
+    );
+};

--- a/src/widgets/friendly-duel/ui/FriendlyDuelFlow.tsx
+++ b/src/widgets/friendly-duel/ui/FriendlyDuelFlow.tsx
@@ -28,33 +28,16 @@ import {
     returnToFriendlyDuelConfiguration,
     selectFriendlyDuelConfiguration,
     selectFriendlyDuelDefaultConfiguration,
+    setFriendlyDuelUserId,
     setFriendlyDuelNickname,
     showFriendlyDuelConfigurationStep,
     showFriendlyDuelOpponentStep,
 } from "../model/friendlyDuelSlice";
 import { isFriendlyDuelConfigurationScenarioActive } from "../model/configurationScenario";
+import { getFriendlyDuelCreationError } from "../model/creationError";
 import { selectFriendlyDuel } from "../model/selectors";
 
 import styles from "./FriendlyDuelFlow.module.scss";
-
-const getCreationError = (error: unknown) => {
-    if (
-        error &&
-        typeof error === "object" &&
-        "status" in error &&
-        (error as { status?: number }).status === 409
-    ) {
-        return {
-            title: "Не получилось отправить вызов на дуэль",
-            description: "Возможно, у вас уже есть вызов на дуэль от этого пользователя.",
-        };
-    }
-
-    return {
-        title: "Не получилось отправить вызов на дуэль",
-        description: "Проверьте соединение и попробуйте ещё раз.",
-    };
-};
 
 const SelectedConfiguration = ({
     configurationId,
@@ -142,6 +125,10 @@ export const FriendlyDuelFlow = () => {
     sessionRef.current = { phase, activeDuelId };
 
     useEffect(() => {
+        dispatch(setFriendlyDuelUserId(user?.id ?? null));
+    }, [dispatch, user?.id]);
+
+    useEffect(() => {
         if (
             friendlyDuel.status === "idle" &&
             phase === "searching" &&
@@ -227,7 +214,7 @@ export const FriendlyDuelFlow = () => {
                 return;
             }
 
-            dispatch(failFriendlyDuelCreation(getCreationError(error)));
+            dispatch(failFriendlyDuelCreation(getFriendlyDuelCreationError(error)));
             dispatch(setPhase("idle"));
         }
     };
@@ -235,10 +222,10 @@ export const FriendlyDuelFlow = () => {
     const isConfigurationScenarioActive = isFriendlyDuelConfigurationScenarioActive(friendlyDuel);
     const cancellationDescription =
         friendlyDuel.cancellationReason === "user"
-            ? "Поиск отменён. Выбранные правила и никнейм сохранены для повторного вызова."
-            : friendlyDuel.cancellationReason === "disconnect"
-              ? "Соединение было прервано, поэтому поиск остановлен."
-              : "Вызов больше не ожидает ответа соперника.";
+              ? "Поиск отменён. Выбранные правила и никнейм сохранены для повторного вызова."
+              : friendlyDuel.cancellationReason === "disconnect"
+                ? "Соединение было прервано, поэтому поиск остановлен."
+                : "Соперник отклонил дружескую дуэль";
 
     return (
         <>
@@ -363,7 +350,7 @@ export const FriendlyDuelFlow = () => {
 
             {friendlyDuel.status === "canceled" && (
                 <Modal
-                    title="Дружеский вызов отменён"
+                    title="Дружеская дуэль отменена"
                     onClose={() => dispatch(closeFriendlyDuel())}
                 >
                     <p className={styles.resultDescription}>{cancellationDescription}</p>

--- a/src/widgets/friendly-duel/ui/FriendlyDuelPendingButton.tsx
+++ b/src/widgets/friendly-duel/ui/FriendlyDuelPendingButton.tsx
@@ -1,0 +1,71 @@
+import { useCancelDuelInvitationMutation } from "entities/duel-invitation";
+import {
+    setPhase,
+    setSearchConfigurationId,
+    setSearchInvitationType,
+    setSearchNickname,
+    setSearchTournamentId,
+} from "features/duel-session";
+import { useAppDispatch, useAppSelector } from "shared/lib/storeHooks";
+import { Button, StatusCard } from "shared/ui";
+
+import {
+    cancelFriendlyDuel,
+    clearFriendlyDuelError,
+    failFriendlyDuelCancellation,
+    requestFriendlyDuelCancellation,
+} from "../model/friendlyDuelSlice";
+import { selectFriendlyDuel } from "../model/selectors";
+
+import styles from "./FriendlyDuelFlow.module.scss";
+
+export const FriendlyDuelPendingButton = () => {
+    const dispatch = useAppDispatch();
+    const friendlyDuel = useAppSelector(selectFriendlyDuel);
+    const [cancelInvitation, { isLoading }] = useCancelDuelInvitationMutation();
+
+    if (friendlyDuel.status !== "pending") return null;
+
+    const handleCancel = async () => {
+        if (friendlyDuel.isCanceling || isLoading) return;
+
+        dispatch(requestFriendlyDuelCancellation());
+        try {
+            await cancelInvitation({
+                opponent_nickname: friendlyDuel.nickname,
+                configuration_id: friendlyDuel.usesDefaultConfiguration
+                    ? undefined
+                    : (friendlyDuel.configurationId ?? undefined),
+            }).unwrap();
+            dispatch(setSearchNickname(null));
+            dispatch(setSearchConfigurationId(null));
+            dispatch(setSearchInvitationType(null));
+            dispatch(setSearchTournamentId(null));
+            dispatch(setPhase("idle"));
+            dispatch(cancelFriendlyDuel("user"));
+        } catch {
+            dispatch(
+                failFriendlyDuelCancellation({
+                    title: "Не удалось отменить вызов",
+                    description: "Проверьте соединение и попробуйте ещё раз.",
+                }),
+            );
+        }
+    };
+
+    return (
+        <div className={styles.pendingControl}>
+            {friendlyDuel.error && (
+                <StatusCard
+                    variant="error"
+                    title={friendlyDuel.error.title}
+                    description={friendlyDuel.error.description}
+                    onClose={() => dispatch(clearFriendlyDuelError())}
+                />
+            )}
+            <Button onClick={handleCancel} disabled={friendlyDuel.isCanceling || isLoading}>
+                {friendlyDuel.isCanceling || isLoading ? "Отмена..." : "Отменить"}
+            </Button>
+        </div>
+    );
+};


### PR DESCRIPTION
## What changed

- moved the friendly-duel flow from `HomePage` into a dedicated widget with explicit `idle → configuring → pending → matched/canceled/error` states;
- canceling an outgoing invitation uses the direct invitation endpoint and preserves configuration/nickname for retry;
- refined cancellation feedback: **«Дружеская дуэль отменена»**, a clear opponent-denial message, and more space before actions;
- a 404 when creating an invitation now explains that no opponent has that nickname;
- an idle sibling tab accepts an authoritative `DuelStarted`, while a cancellation fence rejects late start events;
- friendly-duel state resets on logout and authenticated-user change;
- updated process documentation and focused tests.

Closes #62.

## Verification

- `pnpm test` — 63 passed
- `pnpm lint` — no errors (4 pre-existing warnings)
- `pnpm fsd:lint` — no new findings; repository baseline remains
- production build with `VITE_BASE_URL=http://localhost/api`
- authenticated headless-Chrome production smoke test: root mounted, no console or error-boundary failures; configuration requests were `0` in idle and `1` after opening the friendly flow.

## What to test manually

1. On Home, select **Начать → Дружеская дуэль**, choose rules, enter a known nickname, and send the challenge.
2. Have the opponent deny it. Verify the modal says **«Дружеская дуэль отменена»** and **«Соперник отклонил дружескую дуэль»**, with a clear gap before the action buttons.
3. Enter a nonexistent nickname and submit. Verify the error explains **«Не найден соперник с таким никнеймом»**.
4. In a second browser tab, start or accept a duel. Verify the idle tab opens that duel; after canceling a search, verify a delayed start event does not reopen it.