### PR TITLE
feat(duel-configuration): show task rating ranges

### DIFF
--- a/src/entities/duel-configuration/api/duelConfigurationApi.ts
+++ b/src/entities/duel-configuration/api/duelConfigurationApi.ts
@@ -3,6 +3,7 @@ import { apiSlice } from "shared/api";
 import {
     CreateDuelConfigurationRequest,
     DuelConfiguration,
+    TaskLevelRatingRanges,
     UpdateDuelConfigurationRequest,
 } from "../model/types";
 
@@ -13,6 +14,9 @@ interface UpdateDuelConfigurationArgs {
 
 export const duelConfigurationApiSlice = apiSlice.injectEndpoints({
     endpoints: (builder) => ({
+        getTaskLevelRatingRanges: builder.query<TaskLevelRatingRanges, void>({
+            query: () => "/duels/task-level-rating-ranges",
+        }),
         getDuelConfigurations: builder.query<DuelConfiguration[], void>({
             query: () => "/duels/configurations",
             providesTags: (result) =>
@@ -63,6 +67,7 @@ export const duelConfigurationApiSlice = apiSlice.injectEndpoints({
 });
 
 export const {
+    useGetTaskLevelRatingRangesQuery,
     useGetDuelConfigurationsQuery,
     useCreateDuelConfigurationMutation,
     useUpdateDuelConfigurationMutation,

--- a/src/entities/duel-configuration/index.ts
+++ b/src/entities/duel-configuration/index.ts
@@ -3,6 +3,7 @@ export {
     useDeleteDuelConfigurationMutation,
     useGetDuelConfigurationsQuery,
     useGetDuelConfigurationQuery,
+    useGetTaskLevelRatingRangesQuery,
     useUpdateDuelConfigurationMutation,
 } from "./api/duelConfigurationApi";
 
@@ -11,5 +12,6 @@ export type {
     DuelConfiguration,
     DuelTaskConfiguration,
     DuelTasksOrder,
+    TaskLevelRatingRanges,
     UpdateDuelConfigurationRequest,
 } from "./model/types";

--- a/src/entities/duel-configuration/model/types.ts
+++ b/src/entities/duel-configuration/model/types.ts
@@ -5,6 +5,8 @@ export interface DuelTaskConfiguration {
     topics: string[] | null;
 }
 
+export type TaskLevelRatingRanges = Record<string, string>;
+
 export interface DuelConfiguration {
     id: number;
     should_show_opponent_solution: boolean;

--- a/src/features/duel-configuration/ui/DuelConfigurationManager.tsx
+++ b/src/features/duel-configuration/ui/DuelConfigurationManager.tsx
@@ -546,7 +546,7 @@ export const DuelConfigurationManager = ({
                                             <div key={task.id} className={styles.taskRow}>
                                                 <div className={styles.selectField}>
                                                     <span className={styles.selectLabel}>
-                                                        Рейтинг пользователя
+                                                        Рейтинг задачи
                                                     </span>
                                                     {isTaskLevelRatingRangesLoading ? (
                                                         <span className={styles.helperText}>

--- a/src/features/duel-configuration/ui/DuelConfigurationManager.tsx
+++ b/src/features/duel-configuration/ui/DuelConfigurationManager.tsx
@@ -7,6 +7,7 @@ import {
     DuelTasksOrder,
     useCreateDuelConfigurationMutation,
     useDeleteDuelConfigurationMutation,
+    useGetTaskLevelRatingRangesQuery,
     useUpdateDuelConfigurationMutation,
 } from "entities/duel-configuration";
 import { useGetTaskTopicsQuery } from "entities/task";
@@ -32,11 +33,6 @@ interface StoredDuelConfiguration {
 }
 
 const DEFAULT_DURATION_MINUTES = "30";
-
-const LEVEL_OPTIONS = Array.from({ length: 10 }, (_, index) => {
-    const value = String(index + 1);
-    return { value, label: value };
-});
 
 const TASK_ORDER_OPTIONS: Array<{
     value: DuelTasksOrder;
@@ -107,6 +103,11 @@ export const DuelConfigurationManager = ({
     onCreated,
 }: Props) => {
     const { data: topicsData } = useGetTaskTopicsQuery();
+    const {
+        data: taskLevelRatingRanges,
+        isError: isTaskLevelRatingRangesError,
+        isLoading: isTaskLevelRatingRangesLoading,
+    } = useGetTaskLevelRatingRangesQuery();
     const [configs, setConfigs] = useLocalStorage<StoredDuelConfiguration[]>(
         "duel-configurations",
         [],
@@ -125,6 +126,14 @@ export const DuelConfigurationManager = ({
 
     const isSubmitting = isCreating || isUpdating;
 
+    const taskLevelOptions = useMemo(
+        () =>
+            Object.entries(taskLevelRatingRanges ?? {})
+                .sort(([leftLevel], [rightLevel]) => Number(leftLevel) - Number(rightLevel))
+                .map(([level, ratingRange]) => ({ value: level, label: ratingRange })),
+        [taskLevelRatingRanges],
+    );
+
     const taskCount = tasks.length;
 
     const headerLabel = editingId ? "Редактирование правил" : "Создать новые правила";
@@ -133,9 +142,12 @@ export const DuelConfigurationManager = ({
         return tasks.map((task, index) => {
             const taskKey = String.fromCharCode(65 + index);
             const topicText = task.topics.length > 0 ? ` | ${task.topics.join(", ")}` : "";
-            return `${taskKey}: уровень ${task.level}${topicText}`;
+            const ratingRange = taskLevelRatingRanges?.[task.level];
+            return ratingRange
+                ? `${taskKey}: рейтинг ${ratingRange}${topicText}`
+                : `${taskKey}: уровень ${task.level}${topicText}`;
         });
-    }, [tasks]);
+    }, [taskLevelRatingRanges, tasks]);
 
     const resetForm = () => {
         setEditingId(null);
@@ -223,8 +235,18 @@ export const DuelConfigurationManager = ({
             return;
         }
 
+        if (isTaskLevelRatingRangesLoading || isTaskLevelRatingRangesError) {
+            setFormError("Не удалось загрузить диапазоны рейтинга для уровней задач.");
+            return;
+        }
+
         if (tasks.some((task) => Number(task.level) <= 0 || Number.isNaN(Number(task.level)))) {
-            setFormError("Для каждой задачи выберите уровень от 1 до 10.");
+            setFormError("Для каждой задачи выберите диапазон рейтинга.");
+            return;
+        }
+
+        if (tasks.some((task) => !taskLevelRatingRanges?.[task.level])) {
+            setFormError("Выбранный уровень задачи отсутствует в настройке диапазонов рейтинга.");
             return;
         }
 
@@ -350,7 +372,10 @@ export const DuelConfigurationManager = ({
                                         task.topics && task.topics.length > 0
                                             ? ` | ${task.topics.join(", ")}`
                                             : "";
-                                    return `${taskKey}: уровень ${task.level}${topics}`;
+                                    const ratingRange = taskLevelRatingRanges?.[String(task.level)];
+                                    return ratingRange
+                                        ? `${taskKey}: рейтинг ${ratingRange}${topics}`
+                                        : `${taskKey}: уровень ${task.level}${topics}`;
                                 });
 
                                 return (
@@ -521,22 +546,35 @@ export const DuelConfigurationManager = ({
                                             <div key={task.id} className={styles.taskRow}>
                                                 <div className={styles.selectField}>
                                                     <span className={styles.selectLabel}>
-                                                        Уровень задачи
+                                                        Рейтинг пользователя
                                                     </span>
-                                                    <Select
-                                                        value={task.level}
-                                                        onChange={(value) => {
-                                                            setTasks((prev) =>
-                                                                prev.map((item) =>
-                                                                    item.id === task.id
-                                                                        ? { ...item, level: value }
-                                                                        : item,
-                                                                ),
-                                                            );
-                                                        }}
-                                                        options={LEVEL_OPTIONS}
-                                                        className={styles.select}
-                                                    />
+                                                    {isTaskLevelRatingRangesLoading ? (
+                                                        <span className={styles.helperText}>
+                                                            Загрузка диапазонов рейтинга…
+                                                        </span>
+                                                    ) : isTaskLevelRatingRangesError ? (
+                                                        <span className={styles.errorText}>
+                                                            Не удалось загрузить диапазоны рейтинга.
+                                                        </span>
+                                                    ) : (
+                                                        <Select
+                                                            value={task.level}
+                                                            onChange={(value) => {
+                                                                setTasks((prev) =>
+                                                                    prev.map((item) =>
+                                                                        item.id === task.id
+                                                                            ? {
+                                                                                  ...item,
+                                                                                  level: value,
+                                                                              }
+                                                                            : item,
+                                                                    ),
+                                                                );
+                                                            }}
+                                                            options={taskLevelOptions}
+                                                            className={styles.select}
+                                                        />
+                                                    )}
                                                 </div>
 
                                                 <div className={styles.topics}>
@@ -644,7 +682,14 @@ export const DuelConfigurationManager = ({
 
                                 {formError && <p className={styles.errorText}>{formError}</p>}
 
-                                <Button type="submit" disabled={isSubmitting}>
+                                <Button
+                                    type="submit"
+                                    disabled={
+                                        isSubmitting ||
+                                        isTaskLevelRatingRangesLoading ||
+                                        isTaskLevelRatingRangesError
+                                    }
+                                >
                                     {editingId ? "Сохранить изменения" : "Создать правила"}
                                 </Button>
                             </form>

--- a/src/features/duel-configuration/ui/DuelConfigurationManager.tsx
+++ b/src/features/duel-configuration/ui/DuelConfigurationManager.tsx
@@ -145,7 +145,7 @@ export const DuelConfigurationManager = ({
             const ratingRange = taskLevelRatingRanges?.[task.level];
             return ratingRange
                 ? `${taskKey}: рейтинг ${ratingRange}${topicText}`
-                : `${taskKey}: уровень ${task.level}${topicText}`;
+                : `${taskKey}: рейтинг не определен${topicText}`;
         });
     }, [taskLevelRatingRanges, tasks]);
 
@@ -246,7 +246,7 @@ export const DuelConfigurationManager = ({
         }
 
         if (tasks.some((task) => !taskLevelRatingRanges?.[task.level])) {
-            setFormError("Выбранный уровень задачи отсутствует в настройке диапазонов рейтинга.");
+            setFormError("Для выбранной задачи не задан диапазон рейтинга.");
             return;
         }
 
@@ -375,7 +375,7 @@ export const DuelConfigurationManager = ({
                                     const ratingRange = taskLevelRatingRanges?.[String(task.level)];
                                     return ratingRange
                                         ? `${taskKey}: рейтинг ${ratingRange}${topics}`
-                                        : `${taskKey}: уровень ${task.level}${topics}`;
+                                        : `${taskKey}: рейтинг не определен${topics}`;
                                 });
 
                                 return (

--- a/src/features/duel-configuration/ui/DuelConfigurationPicker.tsx
+++ b/src/features/duel-configuration/ui/DuelConfigurationPicker.tsx
@@ -7,6 +7,7 @@ import {
     DuelTasksOrder,
     useDeleteDuelConfigurationMutation,
     useGetDuelConfigurationsQuery,
+    useGetTaskLevelRatingRangesQuery,
 } from "entities/duel-configuration";
 import { Button, Modal } from "shared/ui";
 
@@ -48,6 +49,11 @@ export const DuelConfigurationPicker = ({
     className,
 }: Props) => {
     const { data: configs, isLoading, isError } = useGetDuelConfigurationsQuery();
+    const {
+        data: taskLevelRatingRanges,
+        isLoading: isTaskLevelRatingRangesLoading,
+        isError: isTaskLevelRatingRangesError,
+    } = useGetTaskLevelRatingRangesQuery();
     const [deleteConfiguration, { isLoading: isDeleting }] = useDeleteDuelConfigurationMutation();
     const [pendingDelete, setPendingDelete] = useState<StoredDuelConfiguration | null>(null);
     const normalizedConfigs: StoredDuelConfiguration[] =
@@ -80,7 +86,7 @@ export const DuelConfigurationPicker = ({
                 </div>
             </div>
 
-            {isLoading ? (
+            {isLoading || isTaskLevelRatingRangesLoading ? (
                 <p className={styles.emptyState}>Загрузка правил...</p>
             ) : (
                 <>
@@ -103,7 +109,7 @@ export const DuelConfigurationPicker = ({
                                 </div>
                                 <div className={styles.configMeta}>Одна задача.</div>
                                 <div className={styles.taskSummary}>
-                                    <div>Уровень определяется автоматически.</div>
+                                    <div>Рейтинг задачи определяется автоматически.</div>
                                 </div>
                             </div>
                         </button>
@@ -121,7 +127,7 @@ export const DuelConfigurationPicker = ({
                             </Button>
                         </div>
                     )}
-                    {isError ? (
+                    {isError || isTaskLevelRatingRangesError ? (
                         <p className={styles.emptyState}>Не удалось загрузить правила.</p>
                     ) : normalizedConfigs.length === 0 ? (
                         <p className={styles.emptyState}>Пока нет созданных правил.</p>
@@ -142,7 +148,8 @@ export const DuelConfigurationPicker = ({
                                         task.topics && task.topics.length > 0
                                             ? ` | ${task.topics.join(", ")}`
                                             : "";
-                                    return `${taskKey}: уровень ${task.level}${topics}`;
+                                    const ratingRange = taskLevelRatingRanges?.[String(task.level)];
+                                    return `${taskKey}: рейтинг ${ratingRange ?? "не определен"}${topics}`;
                                 });
 
                                 return (

--- a/src/widgets/friendly-duel/ui/FriendlyDuelFlow.tsx
+++ b/src/widgets/friendly-duel/ui/FriendlyDuelFlow.tsx
@@ -2,7 +2,10 @@ import { useEffect, useRef, useState, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 
 import type { DuelConfiguration } from "entities/duel-configuration";
-import { useGetDuelConfigurationsQuery } from "entities/duel-configuration";
+import {
+    useGetDuelConfigurationsQuery,
+    useGetTaskLevelRatingRangesQuery,
+} from "entities/duel-configuration";
 import { useCreateDuelInvitationMutation } from "entities/duel-invitation";
 import { DuelConfigurationManager, DuelConfigurationPicker } from "features/duel-configuration";
 import {
@@ -47,6 +50,7 @@ const SelectedConfiguration = ({
     usesDefaultConfiguration: boolean;
 }) => {
     const { data: configurations } = useGetDuelConfigurationsQuery();
+    const { data: taskLevelRatingRanges } = useGetTaskLevelRatingRangesQuery();
     const selectedConfiguration = configurations?.find((config) => config.id === configurationId);
 
     if (usesDefaultConfiguration || !selectedConfiguration) {
@@ -60,7 +64,7 @@ const SelectedConfiguration = ({
                     </div>
                     <div className={configStyles.configMeta}>Одна задача.</div>
                     <div className={configStyles.taskSummary}>
-                        <div>Уровень определяется автоматически.</div>
+                        <div>Рейтинг задачи определяется автоматически.</div>
                     </div>
                 </div>
             </div>
@@ -72,7 +76,8 @@ const SelectedConfiguration = ({
         .map(([, task], index) => {
             const taskKey = String.fromCharCode(65 + index);
             const topics = task.topics?.length ? ` | ${task.topics.join(", ")}` : "";
-            return `${taskKey}: уровень ${task.level}${topics}`;
+            const ratingRange = taskLevelRatingRanges?.[String(task.level)];
+            return `${taskKey}: рейтинг ${ratingRange ?? "не определен"}${topics}`;
         });
     const orderLabel =
         selectedConfiguration.task_order === "Sequential"


### PR DESCRIPTION
## Что изменилось

- Добавлен RTK Query-запрос диапазонов рейтинга задач из Duely.
- В форме создания и редактирования правил дуэли вместо уровней 1–10 отображаются диапазоны рейтинга, например `0-599`.
- Сводки в форме, списке конфигураций и карточке выбранных правил также используют диапазоны рейтинга.
- Сохранение блокируется, пока отображение не загружено или недоступно.
- Подпись поля уточнена до `Рейтинг задачи`.

## Пользовательский эффект

Пользователь выбирает и видит понятный диапазон рейтинга задачи, а в API конфигурации по-прежнему передаётся внутренний уровень задачи.

## Проверка

- `pnpm lint`
- `pnpm test` — 66 тестов пройдено
- `pnpm build` с `VITE_BASE_URL=http://127.0.0.1:4173/api`
- Headless Chrome: авторизованный тестовый сценарий открыл список правил и показал `A: рейтинг 0-599`, `B: рейтинг 1300-1599`; ошибок браузера нет.

`pnpm fsd:lint` сейчас падает на 12 существующих нарушениях в несвязанных модулях.