### PR TITLE
Hide playoff bracket option from tournament creation

### DIFF
--- a/src/pages/group/ui/GroupPage/GroupPage.tsx
+++ b/src/pages/group/ui/GroupPage/GroupPage.tsx
@@ -75,6 +75,10 @@ const tournamentMatchmakingOptions: Array<{
     },
 ];
 
+const visibleTournamentMatchmakingOptions = tournamentMatchmakingOptions.filter(
+    (option) => option.value !== "SingleEliminationBracket",
+);
+
 const isManagerRole = (role: GroupRole | null) => role === "Creator" || role === "Manager";
 
 const extractInviter = (member: GroupUser) => {
@@ -244,7 +248,7 @@ const GroupPage = () => {
     const [tournamentName, setTournamentName] = useState("");
     const [tournamentParticipants, setTournamentParticipants] = useState<number[]>([]);
     const [tournamentMatchmakingType, setTournamentMatchmakingType] =
-        useState<TournamentMatchmakingType>("SingleEliminationBracket");
+        useState<TournamentMatchmakingType>("GroupStage");
     const [tournamentFormError, setTournamentFormError] = useState<string | null>(null);
     const [selectedTournamentConfigId, setSelectedTournamentConfigId] = useState<number | null>(
         null,
@@ -568,7 +572,7 @@ const GroupPage = () => {
         setTournamentStep(1);
         setTournamentName("");
         setTournamentParticipants([]);
-        setTournamentMatchmakingType("SingleEliminationBracket");
+        setTournamentMatchmakingType("GroupStage");
         setTournamentFormError(null);
         setSelectedTournamentConfigId(null);
         setSelectedTournamentDefaultConfig(true);
@@ -1764,7 +1768,7 @@ const GroupPage = () => {
                         {tournamentStep === 3 && (
                             <div className={styles.tournamentStage}>
                                 <div className={styles.schemeList}>
-                                    {tournamentMatchmakingOptions.map((option) => (
+                                    {visibleTournamentMatchmakingOptions.map((option) => (
                                         <button
                                             key={option.value}
                                             type="button"


### PR DESCRIPTION
## Summary

- hide the playoff bracket scheme from the tournament creation form
- keep the existing playoff implementation intact
- default and reset the form to the available Group Stage scheme

Closes #88

## Verification

- TypeScript check passed
- Vitest: 24 files, 66 tests passed
- Production build passed
- Full lint/FSD checks were not completed because the mounted environment timed out

