### PR TITLE
feat(admin): add observability dashboard

### DIFF
--- a/docs/processes/README.md
+++ b/docs/processes/README.md
@@ -10,6 +10,7 @@ contracts. An implementation fact is not automatically a product requirement.
 | ------------------------------------------------------ | -------------------------------------------------------------------------------- | ------------------------------- |
 | Store rehydration, theme, routes, protected pages      | [Application bootstrap and routing](application-bootstrap-and-routing.md)        | `app`                           |
 | Login, logout, and refresh mutex                       | [Authentication and token refresh](authentication-and-token-refresh.md)          | `features/auth`, `shared/api`   |
+| Read-only users, duels, submissions, groups, tournaments | [Admin dashboard](admin-dashboard.md)                                           | admin page/entities             |
 | Redux, cache, local/component/browser state catalog    | [Client state ownership](client-state-ownership.md)                              | store and browser               |
 | Ticket, socket, events, code sync, two tabs            | [Realtime connection](realtime-connection.md)                                    | `features/duel-session`         |
 | Persisted `idle/searching/active` reconciliation       | [Duel session lifecycle](duel-session-lifecycle.md)                              | duel-session slice/manager      |

--- a/docs/processes/admin-dashboard.md
+++ b/docs/processes/admin-dashboard.md
@@ -30,8 +30,11 @@ list queries when it mounts. Users are displayed as active users followed by all
 remaining users. Pending duels are split into
 friendly, group, and tournament subsections, while ranked searchers have a live
 waiting duration. Testing submissions are followed by the `Done` subset of the
-all-submissions response. Groups are sorted by the backend, and group names are
-used to enrich tournament rows when that query is available.
+all-submissions response. Testing rows use a yellow status, `Accepted` uses
+green, and every other terminal verdict uses red. Each submission number links
+to its detail inside the owning duel and selects the row's task through the URL.
+Groups are sorted by the backend, and group names are used to enrich tournament
+rows when that query is available.
 
 All five main sections use accessible native `details` controls and start open.
 Their open state is local to the page. Each data block has independent loading,
@@ -60,7 +63,9 @@ Admin endpoints return creation-time ordering except groups, which are ordered
 by name. `/users/admin/all` includes active users, so the client subtracts IDs
 returned by `/users/admin/active`. `/duels/admin/submissions/all` includes both
 testing and finished submissions, so the client keeps `Done` entries for the
-completed subsection.
+completed subsection. Administrative submission rows expose `duel_id` and
+`task_key`; the corresponding regular duel/detail endpoints must allow an admin
+to read that duel and submission.
 
 ## State ownership
 
@@ -91,9 +96,10 @@ not streamed into the dashboard.
 ## Test coverage
 
 Helper tests cover access-token admin-claim parsing, active-user subtraction,
-terminal-submission selection, pending-duel grouping, waiting duration, and
-invalid dates. The publication smoke test covers admin and non-admin authenticated
-cold startup at `/admin`.
+terminal-submission selection and status tones, submission deep-link building,
+pending-duel grouping, waiting duration, and invalid dates. The publication
+smoke test covers admin and non-admin authenticated cold startup at `/admin` and
+the admin transition from a submission row to its detail inside the duel page.
 
 ## Current guarantees
 

--- a/docs/processes/admin-dashboard.md
+++ b/docs/processes/admin-dashboard.md
@@ -23,8 +23,11 @@ not replace that backend policy.
 
 ## Current behavior
 
-The page starts all eleven admin list queries when it mounts. Users are displayed
-as active users followed by all remaining users. Pending duels are split into
+The page first reads the `is_admin` claim from the access token. An authenticated
+non-admin stays on `/admin`, sees the dedicated access-denied screen, and starts
+no admin list queries. For an administrator, the page starts all eleven admin
+list queries when it mounts. Users are displayed as active users followed by all
+remaining users. Pending duels are split into
 friendly, group, and tournament subsections, while ranked searchers have a live
 waiting duration. Testing submissions are followed by the `Done` subset of the
 all-submissions response. Groups are sorted by the backend, and group names are
@@ -33,8 +36,9 @@ used to enrich tournament rows when that query is available.
 All five main sections use accessible native `details` controls and start open.
 Their open state is local to the page. Each data block has independent loading,
 empty, and failure output. Any admin query returning 403 replaces the dashboard
-with a dedicated access-denied screen. User, group, tournament, and duel links
-use the existing application routes.
+with the same access-denied screen. This remains the fallback when a token claims
+admin access but Duely rejects it. User, group, tournament, and duel links use
+the existing application routes.
 
 The current backend `DuelDto` does not identify whether an active or finished
 duel originated as Friendly, Group, or Tournament and does not include related
@@ -66,10 +70,11 @@ search wait time. No dashboard state is persisted.
 
 ## Failure handling
 
-A 403 from any admin query is treated as an authorization failure. Other request
-failures remain local to the affected data block, allowing other lists to stay
-usable. Missing group lookup data falls back to `Группа #id`. Missing or invalid
-dates render an em dash.
+A missing or false `is_admin` access-token claim is treated as an authorization
+failure before admin requests start. A 403 from any admin query is also treated
+as an authorization failure. Other request failures remain local to the affected
+data block, allowing other lists to stay usable. Missing group lookup data falls
+back to `Группа #id`. Missing or invalid dates render an em dash.
 
 ## Reload and multiple tabs
 
@@ -85,16 +90,18 @@ not streamed into the dashboard.
 
 ## Test coverage
 
-Helper tests cover active-user subtraction, terminal-submission selection,
-pending-duel grouping, waiting duration, and invalid dates. The publication
-smoke test covers authenticated cold startup and the populated `/admin` route.
+Helper tests cover access-token admin-claim parsing, active-user subtraction,
+terminal-submission selection, pending-duel grouping, waiting duration, and
+invalid dates. The publication smoke test covers admin and non-admin authenticated
+cold startup at `/admin`.
 
 ## Current guarantees
 
-The dashboard never grants authorization by itself; it displays only data
-accepted by `OnlyAdmin`, excludes active users from the second user list,
-excludes non-terminal submissions from the completed list, and keeps all entity
-links on declared application routes.
+The dashboard never grants authorization by itself; client-side claim parsing
+only avoids known-forbidden requests, while Duely's `OnlyAdmin` policy remains
+authoritative. It displays only data accepted by that policy, excludes active
+users from the second user list, excludes non-terminal submissions from the
+completed list, and keeps all entity links on declared application routes.
 
 ## Open questions
 

--- a/docs/processes/admin-dashboard.md
+++ b/docs/processes/admin-dashboard.md
@@ -1,0 +1,103 @@
+# Admin dashboard
+
+## Purpose
+
+Give an administrator a read-only overview of users, pending and completed
+work, groups, and tournaments at `/admin`.
+
+## Participants
+
+Administrator, protected router, admin page, domain RTK Query endpoints, Duely,
+and the ordinary profile/group/tournament/duel pages used by dashboard links.
+
+## Entry points
+
+Direct navigation to `/admin`, reload, opening or closing a dashboard section,
+following an entity link, or an authenticated non-admin opening the route.
+
+## Preconditions
+
+The browser has a valid authenticated session. Duely remains responsible for
+authorization through `OnlyAdmin`; the route's normal authentication guard does
+not replace that backend policy.
+
+## Current behavior
+
+The page starts all eleven admin list queries when it mounts. Users are displayed
+as active users followed by all remaining users. Pending duels are split into
+friendly, group, and tournament subsections, while ranked searchers have a live
+waiting duration. Testing submissions are followed by the `Done` subset of the
+all-submissions response. Groups are sorted by the backend, and group names are
+used to enrich tournament rows when that query is available.
+
+All five main sections use accessible native `details` controls and start open.
+Their open state is local to the page. Each data block has independent loading,
+empty, and failure output. Any admin query returning 403 replaces the dashboard
+with a dedicated access-denied screen. User, group, tournament, and duel links
+use the existing application routes.
+
+The current backend `DuelDto` does not identify whether an active or finished
+duel originated as Friendly, Group, or Tournament and does not include related
+group/tournament references. Those two lists therefore expose rated versus
+unrated mode but cannot reproduce the requested type grouping. The current
+`TournamentDto` contains `created_at`, not a tournament start time, so the table
+labels and shows creation time.
+
+## Client state transitions
+
+Each query independently moves from uninitialized/loading to data, empty, or
+error. The page derives inactive users, completed submissions, pending-duel type
+groups, group-name lookup, and aggregate counts without persisting them.
+Collapsible state resets to open when the page remounts.
+
+## Backend state assumptions
+
+Admin endpoints return creation-time ordering except groups, which are ordered
+by name. `/users/admin/all` includes active users, so the client subtracts IDs
+returned by `/users/admin/active`. `/duels/admin/submissions/all` includes both
+testing and finished submissions, so the client keeps `Done` entries for the
+completed subsection.
+
+## State ownership
+
+All displayed domain records belong to Duely. RTK Query owns their in-tab cache;
+the page owns only collapsible state and a one-second clock used to render ranked
+search wait time. No dashboard state is persisted.
+
+## Failure handling
+
+A 403 from any admin query is treated as an authorization failure. Other request
+failures remain local to the affected data block, allowing other lists to stay
+usable. Missing group lookup data falls back to `Группа #id`. Missing or invalid
+dates render an em dash.
+
+## Reload and multiple tabs
+
+Reload and each additional tab issue fresh admin queries because RTK cache is
+not persisted. Tabs keep independent list snapshots and clocks; backend data is
+not streamed into the dashboard.
+
+## Implementation references
+
+- `src/pages/admin`
+- admin query endpoints under `src/entities/{user,duel,submission,group,tournament}`
+- `src/app/router/router.tsx`, `src/shared/config/routes/appRoutes.ts`
+
+## Test coverage
+
+Helper tests cover active-user subtraction, terminal-submission selection,
+pending-duel grouping, waiting duration, and invalid dates. The publication
+smoke test covers authenticated cold startup and the populated `/admin` route.
+
+## Current guarantees
+
+The dashboard never grants authorization by itself; it displays only data
+accepted by `OnlyAdmin`, excludes active users from the second user list,
+excludes non-terminal submissions from the completed list, and keeps all entity
+links on declared application routes.
+
+## Open questions
+
+The backend contract still needs an explicit active/finished duel origin and its
+group/tournament references, plus a tournament start-time field, before the UI
+can exactly match the requested type grouping and time column.

--- a/docs/processes/application-bootstrap-and-routing.md
+++ b/docs/processes/application-bootstrap-and-routing.md
@@ -37,7 +37,7 @@ caught error and renders a router-independent Fallback with a normal home link;
 the router's `errorElement` uses the same component.
 
 `/auth` is public even when already authenticated. Protected routes are `/`,
-`/profile/:userNickname`, `/groups`, `/groups/:groupId`,
+`/admin`, `/profile/:userNickname`, `/groups`, `/groups/:groupId`,
 `/groups/:groupId/members`, `/groups/:groupId/duels`,
 `/groups/:groupId/tournaments`,
 `/groups/:groupId/tournaments/:tournamentId`, and `/duel/:duelId` with nested

--- a/docs/processes/backend-contracts.md
+++ b/docs/processes/backend-contracts.md
@@ -38,7 +38,7 @@ HTTP route catalog from injected endpoints:
 | Tournaments      | `GET /groups/{id}/tournaments`, `POST /tournaments`, `GET /tournaments/{id}`, `POST /tournaments/{id}/start`                                                                                                                        |
 | Tasks/runs       | `GET /task/{id}`, `/task/{id}/{file}`, `/task/topics`; `POST /code-runs`, `GET /code-runs/{id}`                                                                                                                                     |
 | Submissions      | `POST/GET /duels/{id}/submissions`, `GET /duels/{id}/submissions/{submissionId}`                                                                                                                                                    |
-| Admin lists      | `GET /users/admin/{all,active}`, `/duels/admin/{pending,ranked-searchers,active,finished}`, `/duels/admin/submissions/{testing,all}`, `/groups/admin/all`, `/tournaments/admin/{active,finished}`                                      |
+| Admin lists      | `GET /users/admin/{all,active}`, `/duels/admin/{pending,ranked-searchers,active,finished}`, `/duels/admin/submissions/{testing,all}`, `/groups/admin/all`, `/tournaments/admin/{active,finished}`                                   |
 | Actions          | `POST /actions` with `{ actions: [...] }` through raw authenticated fetch                                                                                                                                                           |
 
 Current incoming Duely message enum is `DuelStarted`, `DuelFinished`,
@@ -61,6 +61,8 @@ and tournament-canceled aliases not emitted by current Duely.
 Known DTO boundaries: login/register responses rely on TypeScript only; refresh
 token pair and task test files use Superstruct. Submission list uses
 `submission_id`, while create/detail uses `id`, and code adapts this explicitly.
+Administrative submission-list items additionally expose `duel_id` and
+`task_key` for task-aware detail links.
 Frontend task model/UI focuses on `write_code`, a subset of Taski task types.
 Direct friendly invitations are queried/labeled with client type `Ranked`.
 

--- a/docs/processes/backend-contracts.md
+++ b/docs/processes/backend-contracts.md
@@ -38,6 +38,7 @@ HTTP route catalog from injected endpoints:
 | Tournaments      | `GET /groups/{id}/tournaments`, `POST /tournaments`, `GET /tournaments/{id}`, `POST /tournaments/{id}/start`                                                                                                                        |
 | Tasks/runs       | `GET /task/{id}`, `/task/{id}/{file}`, `/task/topics`; `POST /code-runs`, `GET /code-runs/{id}`                                                                                                                                     |
 | Submissions      | `POST/GET /duels/{id}/submissions`, `GET /duels/{id}/submissions/{submissionId}`                                                                                                                                                    |
+| Admin lists      | `GET /users/admin/{all,active}`, `/duels/admin/{pending,ranked-searchers,active,finished}`, `/duels/admin/submissions/{testing,all}`, `/groups/admin/all`, `/tournaments/admin/{active,finished}`                                      |
 | Actions          | `POST /actions` with `{ actions: [...] }` through raw authenticated fetch                                                                                                                                                           |
 
 Current incoming Duely message enum is `DuelStarted`, `DuelFinished`,

--- a/docs/processes/duel-page-and-task-navigation.md
+++ b/docs/processes/duel-page-and-task-navigation.md
@@ -21,7 +21,8 @@ and `DuelChanged`/`DuelFinished` events.
 
 The route ID must be numeric and the backend must allow viewing. Tasks come from
 the duel DTO; task content/files are fetched from Taski-facing endpoints.
-Participants and spectators receive different editing/submission capabilities.
+Participants, administrators, and ordinary spectators receive different
+editing/submission capabilities.
 
 ## Current behavior
 
@@ -32,7 +33,9 @@ string. Nested index redirects to description while preserving task selection.
 Tasks sort by key. `?task` selects a valid visible task; invalid/missing selection
 is replaced with the first, and legacy `task_id` falls back to key `A`. A task
 with null ID is locked. Participant status controls write/run/submit and
-anti-cheat enabling; spectator UI is read-only, while backend remains authority.
+anti-cheat enabling; spectator UI is read-only. Administrators remain read-only
+but may open submission detail routes that redirect ordinary spectators back to
+the submission list. The backend remains authoritative for access.
 
 ## Client state transitions
 
@@ -62,8 +65,10 @@ documented owners.
 
 ## UI effects
 
-The split view renders code and task panes. Spectators cannot edit/run/submit
-and cannot open submission detail, though they can view submission lists/authors.
+The split view renders code and task panes. Spectators cannot edit/run/submit.
+Ordinary spectators cannot open submission detail, though they can view
+submission lists/authors where permitted; administrators can open any detail
+without gaining participant mutation controls.
 Newly opened tasks can raise DuelInfo modal. A result modal appears only when the
 rendered finished duel matches the current user's pending result. Dismissal is
 shared across tabs but isolated by user and duel.

--- a/docs/processes/submissions.md
+++ b/docs/processes/submissions.md
@@ -14,7 +14,8 @@ and spectator.
 ## Entry points
 
 Click submit, open submissions list or detail, change task filter, receive
-`SubmissionStatusUpdated`, reconnect/reload, revisit a duel, or finish it.
+`SubmissionStatusUpdated`, reconnect/reload, revisit a duel, finish it, or follow
+an administrative submission deep-link.
 
 ## Preconditions
 
@@ -92,8 +93,11 @@ does not persist a submission outbox.
 
 Participant is immediately moved to the submissions page. Empty/loading state
 disables normal repeats, although very fast duplicates are possible. Lists show
-status/verdict; detail is hidden from spectators in UI, while list/authors remain
-visible. Failed submit after navigation can leave the target list unchanged.
+status/verdict; detail is hidden from ordinary spectators in UI, while
+list/authors remain visible. An administrator may open any submission detail and
+the admin dashboard links directly to `/duel/:duelId/submissions/:submissionId`
+with the owning task in the query string. Failed submit after navigation can
+leave the target list unchanged.
 
 ## Network effects
 
@@ -142,8 +146,9 @@ submit duplicates or display different statuses until independently refreshed.
   malformed payload rejection, duplicate cursor isolation, and handler safety.
 - **Needed integration:** all DTO ID shapes, filters/cache keys, status-before-
   create, duplicates, terminal regression, unknown ID, reconnect invalidation.
-- **Needed E2E:** success/failure/response loss, reload/in-flight, spectator,
-  multiple tasks/tabs, delayed judging, and out-of-order statuses.
+- **Needed E2E:** success/failure/response loss, reload/in-flight, ordinary
+  spectator versus administrator detail access, multiple tasks/tabs, delayed
+  judging, and out-of-order statuses.
 
 ## Current guarantees
 

--- a/src/app/router/router.tsx
+++ b/src/app/router/router.tsx
@@ -6,6 +6,7 @@ import { HomePage } from "pages/home";
 import { GroupsPage } from "pages/groups";
 import { GroupPage } from "pages/group";
 import { TournamentPage } from "pages/tournament";
+import { AdminPage } from "pages/admin";
 import { Suspense } from "react";
 import { createBrowserRouter, Navigate } from "react-router-dom";
 import { AppRoutes } from "shared/config";
@@ -40,6 +41,16 @@ export const router = createBrowserRouter([
                             <HomePage />
                         </Suspense>
                     </ProtectedRoute>
+                ),
+            },
+            {
+                path: AppRoutes.ADMIN,
+                element: (
+                    <Suspense fallback={<Loader />}>
+                        <ProtectedRoute>
+                            <AdminPage />
+                        </ProtectedRoute>
+                    </Suspense>
                 ),
             },
             {

--- a/src/entities/duel/api/duelApi.ts
+++ b/src/entities/duel/api/duelApi.ts
@@ -1,6 +1,6 @@
 import { apiSlice } from "shared/api";
 
-import { Duel, GroupDuelEntry } from "../model/types";
+import type { Duel, GroupDuelEntry, PendingDuel, RankedDuelSearcher } from "../model/types";
 
 export const duelApiSlice = apiSlice.injectEndpoints({
     endpoints: (builder) => ({
@@ -35,6 +35,18 @@ export const duelApiSlice = apiSlice.injectEndpoints({
                       ]
                     : [{ type: "Duel", id: `GROUP-${groupId}` }],
         }),
+        getAdminPendingDuels: builder.query<PendingDuel[], void>({
+            query: () => "/duels/admin/pending",
+        }),
+        getAdminRankedDuelSearchers: builder.query<RankedDuelSearcher[], void>({
+            query: () => "/duels/admin/ranked-searchers",
+        }),
+        getAdminActiveDuels: builder.query<Duel[], void>({
+            query: () => "/duels/admin/active",
+        }),
+        getAdminFinishedDuels: builder.query<Duel[], void>({
+            query: () => "/duels/admin/finished",
+        }),
     }),
 });
 
@@ -43,4 +55,8 @@ export const {
     useGetAllUserDuelsQuery,
     useGetActiveDuelQuery,
     useGetGroupDuelsQuery,
+    useGetAdminPendingDuelsQuery,
+    useGetAdminRankedDuelSearchersQuery,
+    useGetAdminActiveDuelsQuery,
+    useGetAdminFinishedDuelsQuery,
 } = duelApiSlice;

--- a/src/entities/duel/index.ts
+++ b/src/entities/duel/index.ts
@@ -5,12 +5,23 @@ export {
     useGetAllUserDuelsQuery,
     useGetActiveDuelQuery,
     useGetGroupDuelsQuery,
+    useGetAdminPendingDuelsQuery,
+    useGetAdminRankedDuelSearchersQuery,
+    useGetAdminActiveDuelsQuery,
+    useGetAdminFinishedDuelsQuery,
 } from "./api/duelApi";
 
 export { DuelResult } from "./ui/DuelResult/DuelResult";
 export { DuelHistory } from "./ui/DuelHistory/DuelHistory";
 
-export type { DuelResultType, Duel, DuelTaskRef } from "./model/types";
+export type {
+    DuelResultType,
+    Duel,
+    DuelTaskRef,
+    PendingDuel,
+    PendingDuelType,
+    RankedDuelSearcher,
+} from "./model/types";
 
 export { getDuelResultForUser } from "./lib/duelResultHelpers";
 export { useDuelTaskSelection } from "./lib/useDuelTaskSelection";

--- a/src/entities/duel/model/types.ts
+++ b/src/entities/duel/model/types.ts
@@ -45,6 +45,28 @@ export interface GroupDuelEntry {
     created_at: string;
 }
 
+export type PendingDuelType = "Friendly" | "Group" | "Tournament";
+
+export interface PendingDuel {
+    id: number;
+    type: PendingDuelType;
+    created_at: string;
+    user1: UserData;
+    user2: UserData;
+    is_accepted_by_user1: boolean;
+    is_accepted_by_user2: boolean;
+    group_id?: number | null;
+    group_name?: string | null;
+    tournament_id?: number | null;
+    tournament_name?: string | null;
+}
+
+export interface RankedDuelSearcher {
+    user: UserData;
+    rating: number;
+    search_started_at: string;
+}
+
 export type DeltaInfo = Record<DuelResultType, number>;
 
 export type DuelResultType = "Win" | "Lose" | "Draw";

--- a/src/entities/group/api/groupApi.ts
+++ b/src/entities/group/api/groupApi.ts
@@ -1,6 +1,12 @@
 import { apiSlice } from "shared/api";
 
-import type { CreateGroupRequest, Group, GroupUser, InviteGroupUserRequest } from "../model/types";
+import type {
+    CreateGroupRequest,
+    Group,
+    GroupListItem,
+    GroupUser,
+    InviteGroupUserRequest,
+} from "../model/types";
 
 export const groupApiSlice = apiSlice.injectEndpoints({
     endpoints: (builder) => ({
@@ -13,6 +19,9 @@ export const groupApiSlice = apiSlice.injectEndpoints({
                           { type: "Group", id: "LIST" },
                       ]
                     : [{ type: "Group", id: "LIST" }],
+        }),
+        getAdminGroups: builder.query<GroupListItem[], void>({
+            query: () => "/groups/admin/all",
         }),
         createGroup: builder.mutation<Group, CreateGroupRequest>({
             query: (body) => ({
@@ -85,4 +94,5 @@ export const {
     useExcludeGroupUserMutation,
     useLeaveGroupMutation,
     useInviteGroupUserMutation,
+    useGetAdminGroupsQuery,
 } = groupApiSlice;

--- a/src/entities/group/index.ts
+++ b/src/entities/group/index.ts
@@ -10,6 +10,7 @@ export {
     useExcludeGroupUserMutation,
     useLeaveGroupMutation,
     useInviteGroupUserMutation,
+    useGetAdminGroupsQuery,
 } from "./api/groupApi";
 
 export type {
@@ -19,6 +20,7 @@ export type {
     GroupUserStatus,
     CreateGroupRequest,
     InviteGroupUserRequest,
+    GroupListItem,
 } from "./model/types";
 
 export { roleLabels } from "./lib/roleLabels";

--- a/src/entities/group/model/types.ts
+++ b/src/entities/group/model/types.ts
@@ -7,6 +7,11 @@ export interface Group {
     user_role: GroupRole;
 }
 
+export interface GroupListItem {
+    id: number;
+    name: string;
+}
+
 export interface CreateGroupRequest {
     name: string;
 }

--- a/src/entities/submission/api/submissionApi.ts
+++ b/src/entities/submission/api/submissionApi.ts
@@ -1,7 +1,12 @@
 import { apiSlice } from "shared/api";
 
 import { isSubmissionStatusForward } from "../model/submissionStatus";
-import type { SubmissionDetail, SubmissionItem, SubmitCodeRequestData } from "../model/types";
+import type {
+    AdminSubmissionItem,
+    SubmissionDetail,
+    SubmissionItem,
+    SubmitCodeRequestData,
+} from "../model/types";
 
 interface SubmissionsQueryArg {
     duelId: string;
@@ -143,10 +148,10 @@ export const submitCodeApiSlice = apiSlice.injectEndpoints({
                 }
             },
         }),
-        getAdminTestingSubmissions: builder.query<SubmissionItem[], void>({
+        getAdminTestingSubmissions: builder.query<AdminSubmissionItem[], void>({
             query: () => "/duels/admin/submissions/testing",
         }),
-        getAdminSubmissions: builder.query<SubmissionItem[], void>({
+        getAdminSubmissions: builder.query<AdminSubmissionItem[], void>({
             query: () => "/duels/admin/submissions/all",
         }),
     }),

--- a/src/entities/submission/api/submissionApi.ts
+++ b/src/entities/submission/api/submissionApi.ts
@@ -143,8 +143,19 @@ export const submitCodeApiSlice = apiSlice.injectEndpoints({
                 }
             },
         }),
+        getAdminTestingSubmissions: builder.query<SubmissionItem[], void>({
+            query: () => "/duels/admin/submissions/testing",
+        }),
+        getAdminSubmissions: builder.query<SubmissionItem[], void>({
+            query: () => "/duels/admin/submissions/all",
+        }),
     }),
 });
 
-export const { useSubmitCodeMutation, useGetSubmissionsQuery, useGetSubmissionDetailQuery } =
-    submitCodeApiSlice;
+export const {
+    useSubmitCodeMutation,
+    useGetSubmissionsQuery,
+    useGetSubmissionDetailQuery,
+    useGetAdminTestingSubmissionsQuery,
+    useGetAdminSubmissionsQuery,
+} = submitCodeApiSlice;

--- a/src/entities/submission/index.ts
+++ b/src/entities/submission/index.ts
@@ -3,6 +3,8 @@ export {
     useGetSubmissionDetailQuery,
     useGetSubmissionsQuery,
     useSubmitCodeMutation,
+    useGetAdminTestingSubmissionsQuery,
+    useGetAdminSubmissionsQuery,
 } from "./api/submissionApi";
 
 export type {

--- a/src/entities/submission/index.ts
+++ b/src/entities/submission/index.ts
@@ -8,6 +8,7 @@ export {
 } from "./api/submissionApi";
 
 export type {
+    AdminSubmissionItem,
     SubmissionDetail,
     SubmissionItem,
     SubmissionStatus,

--- a/src/entities/submission/model/types.ts
+++ b/src/entities/submission/model/types.ts
@@ -19,6 +19,11 @@ export interface SubmissionItem {
     is_upsolving: boolean;
 }
 
+export interface AdminSubmissionItem extends SubmissionItem {
+    duel_id: number;
+    task_key: string;
+}
+
 export interface SubmissionDetail {
     id: number;
     solution: string | null;

--- a/src/entities/tournament/api/tournamentApi.ts
+++ b/src/entities/tournament/api/tournamentApi.ts
@@ -18,6 +18,12 @@ export const tournamentApiSlice = apiSlice.injectEndpoints({
                       ]
                     : [{ type: "Tournament", id: `GROUP-${groupId}` }],
         }),
+        getAdminActiveTournaments: builder.query<Tournament[], void>({
+            query: () => "/tournaments/admin/active",
+        }),
+        getAdminFinishedTournaments: builder.query<Tournament[], void>({
+            query: () => "/tournaments/admin/finished",
+        }),
         createTournament: builder.mutation<Tournament, CreateTournamentRequest>({
             query: (body) => ({
                 url: "/tournaments",
@@ -50,4 +56,6 @@ export const {
     useCreateTournamentMutation,
     useGetTournamentQuery,
     useStartTournamentMutation,
+    useGetAdminActiveTournamentsQuery,
+    useGetAdminFinishedTournamentsQuery,
 } = tournamentApiSlice;

--- a/src/entities/tournament/index.ts
+++ b/src/entities/tournament/index.ts
@@ -5,6 +5,8 @@ export {
     useCreateTournamentMutation,
     useGetTournamentQuery,
     useStartTournamentMutation,
+    useGetAdminActiveTournamentsQuery,
+    useGetAdminFinishedTournamentsQuery,
 } from "./api/tournamentApi";
 export { TournamentBracket } from "./ui/TournamentBracket/TournamentBracket";
 

--- a/src/entities/user/api/userApi.ts
+++ b/src/entities/user/api/userApi.ts
@@ -14,6 +14,12 @@ export const userApiSlice = apiSlice.injectEndpoints({
             query: () => `/users/iam`,
             providesTags: [{ type: "User", id: "ME" }],
         }),
+        getAdminUsers: builder.query<UserData[], void>({
+            query: () => "/users/admin/all",
+        }),
+        getAdminActiveUsers: builder.query<UserData[], void>({
+            query: () => "/users/admin/active",
+        }),
         createTicket: builder.mutation<{ ticket: string }, void>({
             query: () => ({
                 url: "/users/ticket",
@@ -29,4 +35,6 @@ export const {
     useGetUserByNicknameQuery,
     useLazyGetUserByNicknameQuery,
     useGetMeQuery,
+    useGetAdminUsersQuery,
+    useGetAdminActiveUsersQuery,
 } = userApiSlice;

--- a/src/entities/user/index.ts
+++ b/src/entities/user/index.ts
@@ -9,6 +9,8 @@ export {
     useGetUserByNicknameQuery,
     useLazyGetUserByNicknameQuery,
     useGetMeQuery,
+    useGetAdminUsersQuery,
+    useGetAdminActiveUsersQuery,
 } from "./api/userApi";
 
 export { userApiSlice } from "./api/userApi";

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -8,5 +8,6 @@ export { RegisterForm } from "./ui/RegisterForm/RegisterForm";
 export { useLoginMutation, useRegisterMutation } from "./api/authApi";
 
 export { selectAuthToken } from "./model/selectors";
+export { isAdminAccessToken } from "./lib/isAdminAccessToken";
 
 export type { StatusPayload } from "./lib/mapAuthError";

--- a/src/features/auth/lib/isAdminAccessToken.test.ts
+++ b/src/features/auth/lib/isAdminAccessToken.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { isAdminAccessToken } from "./isAdminAccessToken";
+
+const accessToken = (payload: object) => {
+    const encodedPayload = btoa(JSON.stringify(payload))
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+
+    return `header.${encodedPayload}.signature`;
+};
+
+describe("isAdminAccessToken", () => {
+    it.each([true, "True", "true"])("accepts the admin claim %s", (claim) => {
+        expect(isAdminAccessToken(accessToken({ is_admin: claim }))).toBe(true);
+    });
+
+    it.each([false, "False", undefined])("rejects the admin claim %s", (claim) => {
+        expect(isAdminAccessToken(accessToken({ is_admin: claim }))).toBe(false);
+    });
+
+    it("rejects missing and malformed tokens", () => {
+        expect(isAdminAccessToken(null)).toBe(false);
+        expect(isAdminAccessToken("not-a-jwt")).toBe(false);
+        expect(isAdminAccessToken("header.invalid-payload.signature")).toBe(false);
+    });
+});

--- a/src/features/auth/lib/isAdminAccessToken.ts
+++ b/src/features/auth/lib/isAdminAccessToken.ts
@@ -1,0 +1,35 @@
+const decodeTokenPayload = (token: string): unknown => {
+    const payload = token.split(".")[1];
+
+    if (!payload) {
+        return null;
+    }
+
+    const normalizedPayload = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const paddedPayload = normalizedPayload.padEnd(
+        normalizedPayload.length + ((4 - (normalizedPayload.length % 4)) % 4),
+        "=",
+    );
+
+    try {
+        return JSON.parse(atob(paddedPayload));
+    } catch {
+        return null;
+    }
+};
+
+export const isAdminAccessToken = (token: string | null) => {
+    if (!token) {
+        return false;
+    }
+
+    const payload = decodeTokenPayload(token);
+
+    if (typeof payload !== "object" || payload === null || !("is_admin" in payload)) {
+        return false;
+    }
+
+    const isAdmin = payload.is_admin;
+
+    return isAdmin === true || (typeof isAdmin === "string" && isAdmin.toLowerCase() === "true");
+};

--- a/src/pages/admin/index.ts
+++ b/src/pages/admin/index.ts
@@ -1,0 +1,1 @@
+export { AdminPage } from "./ui/AdminPage";

--- a/src/pages/admin/lib/adminPageHelpers.test.ts
+++ b/src/pages/admin/lib/adminPageHelpers.test.ts
@@ -6,6 +6,8 @@ import type { UserData } from "entities/user";
 import {
     formatAdminDateTime,
     formatAdminWaitTime,
+    getAdminSubmissionPath,
+    getAdminSubmissionStatus,
     getCompletedSubmissions,
     getInactiveUsers,
     getPendingDuelsByType,
@@ -35,6 +37,31 @@ describe("admin page helpers", () => {
         expect(
             getCompletedSubmissions(submissions).map(({ submission_id }) => submission_id),
         ).toEqual([3]);
+    });
+
+    it.each([
+        [{ status: "Queued" }, { label: "В очереди", tone: "testing" }],
+        [{ status: "Running" }, { label: "Проверяется", tone: "testing" }],
+        [
+            { status: "Done", verdict: "Accepted" },
+            { label: "Accepted", tone: "accepted" },
+        ],
+        [
+            { status: "Done", verdict: "Wrong answer" },
+            { label: "Wrong answer", tone: "rejected" },
+        ],
+    ] as const)("maps submission status %# to its admin presentation", (submission, expected) => {
+        expect(getAdminSubmissionStatus(submission)).toEqual(expected);
+    });
+
+    it("builds a task-aware submission detail path", () => {
+        expect(
+            getAdminSubmissionPath({
+                duel_id: 17,
+                submission_id: 42,
+                task_key: "B",
+            }),
+        ).toBe("/duel/17/submissions/42?task=B");
     });
 
     it("groups pending duels by backend type", () => {

--- a/src/pages/admin/lib/adminPageHelpers.test.ts
+++ b/src/pages/admin/lib/adminPageHelpers.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import type { PendingDuel } from "entities/duel";
+import type { SubmissionItem } from "entities/submission";
+import type { UserData } from "entities/user";
+import {
+    formatAdminDateTime,
+    formatAdminWaitTime,
+    getCompletedSubmissions,
+    getInactiveUsers,
+    getPendingDuelsByType,
+} from "./adminPageHelpers";
+
+const user = (id: number): UserData => ({
+    id,
+    nickname: `user-${id}`,
+    rating: 1500,
+    created_at: "2026-08-09T10:00:00Z",
+});
+
+describe("admin page helpers", () => {
+    it("removes active users from the remaining users list", () => {
+        expect(
+            getInactiveUsers([user(1), user(2), user(3)], [user(2)]).map(({ id }) => id),
+        ).toEqual([1, 3]);
+    });
+
+    it("keeps only terminal submissions in the completed list", () => {
+        const submissions = [
+            { submission_id: 1, status: "Queued" },
+            { submission_id: 2, status: "Running" },
+            { submission_id: 3, status: "Done" },
+        ] as SubmissionItem[];
+
+        expect(
+            getCompletedSubmissions(submissions).map(({ submission_id }) => submission_id),
+        ).toEqual([3]);
+    });
+
+    it("groups pending duels by backend type", () => {
+        const duels = [
+            { id: 1, type: "Friendly" },
+            { id: 2, type: "Group" },
+            { id: 3, type: "Tournament" },
+            { id: 4, type: "Friendly" },
+        ] as PendingDuel[];
+
+        expect(getPendingDuelsByType(duels, "Friendly").map(({ id }) => id)).toEqual([1, 4]);
+    });
+
+    it("formats waiting time and handles invalid dates", () => {
+        expect(
+            formatAdminWaitTime("2026-08-09T10:00:00Z", Date.parse("2026-08-09T10:01:05Z")),
+        ).toBe("1 мин 5 сек");
+        expect(formatAdminWaitTime("invalid", Date.now())).toBe("—");
+        expect(formatAdminDateTime("invalid")).toBe("—");
+    });
+});

--- a/src/pages/admin/lib/adminPageHelpers.ts
+++ b/src/pages/admin/lib/adminPageHelpers.ts
@@ -1,6 +1,7 @@
 import type { PendingDuel, PendingDuelType } from "entities/duel";
-import type { SubmissionItem } from "entities/submission";
+import type { AdminSubmissionItem, SubmissionItem } from "entities/submission";
 import type { UserData } from "entities/user";
+import { AppRoutes } from "shared/config/routes/appRoutes";
 import { formatDuration } from "shared/lib/timeHelpers";
 
 const dateTimeFormatter = new Intl.DateTimeFormat("ru-RU", {
@@ -32,8 +33,39 @@ export const getInactiveUsers = (users: UserData[], activeUsers: UserData[]) => 
     return users.filter((user) => !activeUserIds.has(user.id));
 };
 
-export const getCompletedSubmissions = (submissions: SubmissionItem[]) =>
+export const getCompletedSubmissions = <T extends SubmissionItem>(submissions: T[]) =>
     submissions.filter((submission) => submission.status === "Done");
+
+export const getAdminSubmissionStatus = (
+    submission: Pick<SubmissionItem, "status" | "verdict">,
+) => {
+    if (submission.status !== "Done") {
+        return {
+            label: submission.status === "Running" ? "Проверяется" : "В очереди",
+            tone: "testing" as const,
+        };
+    }
+
+    if (submission.verdict === "Accepted") {
+        return { label: submission.verdict, tone: "accepted" as const };
+    }
+
+    return {
+        label: submission.verdict ?? "Завершена",
+        tone: "rejected" as const,
+    };
+};
+
+export const getAdminSubmissionPath = (
+    submission: Pick<AdminSubmissionItem, "duel_id" | "submission_id" | "task_key">,
+) => {
+    const detailPath = AppRoutes.DUEL_TASK_SUBMISSION_CODE.replace(
+        ":duelId",
+        String(submission.duel_id),
+    ).replace(":submissionId", String(submission.submission_id));
+
+    return `${detailPath}?task=${encodeURIComponent(submission.task_key)}`;
+};
 
 export const getPendingDuelsByType = (duels: PendingDuel[], type: PendingDuelType) =>
     duels.filter((duel) => duel.type === type);

--- a/src/pages/admin/lib/adminPageHelpers.ts
+++ b/src/pages/admin/lib/adminPageHelpers.ts
@@ -1,0 +1,39 @@
+import type { PendingDuel, PendingDuelType } from "entities/duel";
+import type { SubmissionItem } from "entities/submission";
+import type { UserData } from "entities/user";
+import { formatDuration } from "shared/lib/timeHelpers";
+
+const dateTimeFormatter = new Intl.DateTimeFormat("ru-RU", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+});
+
+export const formatAdminDateTime = (value?: string | null) => {
+    if (!value) return "—";
+
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return "—";
+
+    return dateTimeFormatter.format(date);
+};
+
+export const formatAdminWaitTime = (startedAt: string, now: number) => {
+    const startedAtMs = new Date(startedAt).getTime();
+    if (Number.isNaN(startedAtMs)) return "—";
+
+    return formatDuration(now - startedAtMs);
+};
+
+export const getInactiveUsers = (users: UserData[], activeUsers: UserData[]) => {
+    const activeUserIds = new Set(activeUsers.map((user) => user.id));
+    return users.filter((user) => !activeUserIds.has(user.id));
+};
+
+export const getCompletedSubmissions = (submissions: SubmissionItem[]) =>
+    submissions.filter((submission) => submission.status === "Done");
+
+export const getPendingDuelsByType = (duels: PendingDuel[], type: PendingDuelType) =>
+    duels.filter((duel) => duel.type === type);

--- a/src/pages/admin/ui/AdminPage.module.scss
+++ b/src/pages/admin/ui/AdminPage.module.scss
@@ -1,0 +1,276 @@
+.adminPage {
+    width: 100%;
+    min-width: 0;
+    padding: 2.25em 1.5em 4em;
+    font-family: var(--font-family-sans);
+}
+
+.pageContent {
+    width: min(100%, 1280px);
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1em;
+}
+
+.pageHeader {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45em;
+    margin-bottom: 0.5em;
+}
+
+.pageHeader h1,
+.accessCard h1 {
+    font-size: clamp(1.75rem, 3vw, 2.4rem);
+    line-height: 1.15;
+}
+
+.pageHeader p,
+.accessCard p {
+    color: var(--text-secondary);
+}
+
+.eyebrow {
+    color: var(--accent-primary);
+    font-size: var(--font-size-xs);
+    font-weight: var(--font-weight-bold);
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.sectionCard {
+    overflow: clip;
+    border: 1px solid color-mix(in srgb, var(--card-secondary) 70%, transparent);
+    border-radius: 0.9em;
+    background: var(--card-primary);
+    box-shadow: 0 0.2em 1em rgba(0, 0, 0, 0.05);
+}
+
+.sectionSummary {
+    min-height: 4.25em;
+    display: flex;
+    align-items: center;
+    gap: 0.7em;
+    padding: 1em 1.25em;
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+}
+
+.sectionSummary::-webkit-details-marker {
+    display: none;
+}
+
+.sectionSummary:hover {
+    background: color-mix(in srgb, var(--card-secondary) 28%, transparent);
+}
+
+.sectionSummary:focus-visible {
+    outline: 0.125em solid var(--accent-secondary);
+    outline-offset: -0.25em;
+}
+
+.sectionTitle {
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-bold);
+}
+
+.sectionCount {
+    min-width: 1.8em;
+    padding: 0.18em 0.55em;
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--accent-primary) 14%, transparent);
+    color: var(--accent-primary);
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-semibold);
+    text-align: center;
+}
+
+.sectionChevron {
+    width: 0.65em;
+    height: 0.65em;
+    margin-left: auto;
+    border-right: 0.14em solid var(--text-secondary);
+    border-bottom: 0.14em solid var(--text-secondary);
+    transform: rotate(45deg);
+    transition: transform 0.18s ease;
+}
+
+.sectionCard[open] .sectionChevron {
+    transform: rotate(225deg);
+}
+
+.sectionContent {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5em;
+    padding: 0 1.25em 1.5em;
+    border-top: 1px solid color-mix(in srgb, var(--card-secondary) 55%, transparent);
+}
+
+.subsection {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65em;
+    padding-top: 1.25em;
+}
+
+.subsection + .subsection {
+    border-top: 1px solid color-mix(in srgb, var(--card-secondary) 50%, transparent);
+}
+
+.subsection h2 {
+    font-size: var(--font-size-md);
+    font-weight: var(--font-weight-semibold);
+}
+
+.tableWrapper {
+    max-width: 100%;
+    overflow-x: auto;
+    border: 1px solid color-mix(in srgb, var(--card-secondary) 65%, transparent);
+    border-radius: 0.65em;
+}
+
+.table {
+    width: 100%;
+    min-width: 680px;
+}
+
+.table :global(th),
+.table :global(td) {
+    padding: 0.7em 0.8em;
+    vertical-align: middle;
+}
+
+.table :global(th) {
+    background: color-mix(in srgb, var(--card-secondary) 34%, transparent);
+    white-space: nowrap;
+}
+
+.table :global(tbody tr) {
+    border-top: 1px solid color-mix(in srgb, var(--card-secondary) 50%, transparent);
+}
+
+.table :global(tbody tr:hover) {
+    cursor: default;
+    background: color-mix(in srgb, var(--card-secondary) 24%, transparent);
+}
+
+.entityLink,
+.backLink {
+    color: var(--accent-primary);
+    font-weight: var(--font-weight-medium);
+}
+
+.entityLink:hover,
+.backLink:hover {
+    text-decoration: underline;
+}
+
+.entityLink:focus-visible,
+.backLink:focus-visible {
+    border-radius: 0.2em;
+    outline: 0.125em solid var(--accent-secondary);
+    outline-offset: 0.15em;
+}
+
+.active,
+.inactive,
+.accepted,
+.waiting {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45em;
+    white-space: nowrap;
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-medium);
+}
+
+.statusDot {
+    width: 0.55em;
+    height: 0.55em;
+    flex: 0 0 auto;
+    border-radius: 999px;
+    background: currentColor;
+}
+
+.active,
+.accepted {
+    color: var(--positive);
+}
+
+.inactive {
+    color: var(--text-secondary);
+}
+
+.waiting {
+    color: var(--warning);
+}
+
+.contextLinks {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.2em;
+}
+
+.participants {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35em;
+}
+
+.separator {
+    margin-right: 0.35em;
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+}
+
+.message {
+    padding: 0.85em 1em;
+    border-radius: 0.6em;
+    background: color-mix(in srgb, var(--card-secondary) 40%, transparent);
+    color: var(--text-secondary);
+}
+
+.loader {
+    min-height: 4em;
+}
+
+.accessCard {
+    width: min(100%, 520px);
+    margin: 10vh auto 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.8em;
+    padding: 2em;
+    border-radius: 0.9em;
+    background: var(--card-primary);
+    box-shadow: 0 0.2em 1em rgba(0, 0, 0, 0.08);
+}
+
+.backLink {
+    margin-top: 0.4em;
+}
+
+@media (max-width: 720px) {
+    .adminPage {
+        padding: 1.5em 0.75em 3em;
+    }
+
+    .sectionSummary,
+    .sectionContent {
+        padding-left: 0.9em;
+        padding-right: 0.9em;
+    }
+
+    .sectionTitle {
+        font-size: var(--font-size-md);
+    }
+
+    .table {
+        font-size: var(--font-size-sm);
+    }
+}

--- a/src/pages/admin/ui/AdminPage.module.scss
+++ b/src/pages/admin/ui/AdminPage.module.scss
@@ -178,7 +178,10 @@
 .active,
 .inactive,
 .accepted,
-.waiting {
+.waiting,
+.submissionAccepted,
+.submissionRejected,
+.submissionTesting {
     display: inline-flex;
     align-items: center;
     gap: 0.45em;
@@ -205,6 +208,18 @@
 }
 
 .waiting {
+    color: var(--warning);
+}
+
+.submissionAccepted {
+    color: var(--positive);
+}
+
+.submissionRejected {
+    color: var(--error);
+}
+
+.submissionTesting {
     color: var(--warning);
 }
 

--- a/src/pages/admin/ui/AdminPage.tsx
+++ b/src/pages/admin/ui/AdminPage.tsx
@@ -1,0 +1,643 @@
+import { useEffect, useMemo, useState, type PropsWithChildren } from "react";
+import { Link } from "react-router-dom";
+
+import {
+    type Duel,
+    type PendingDuel,
+    useGetAdminActiveDuelsQuery,
+    useGetAdminFinishedDuelsQuery,
+    useGetAdminPendingDuelsQuery,
+    useGetAdminRankedDuelSearchersQuery,
+} from "entities/duel";
+import { useGetAdminGroupsQuery } from "entities/group";
+import {
+    type SubmissionItem,
+    useGetAdminSubmissionsQuery,
+    useGetAdminTestingSubmissionsQuery,
+} from "entities/submission";
+import {
+    type Tournament,
+    useGetAdminActiveTournamentsQuery,
+    useGetAdminFinishedTournamentsQuery,
+} from "entities/tournament";
+import { type UserData, useGetAdminActiveUsersQuery, useGetAdminUsersQuery } from "entities/user";
+import { AppRoutes, fromApiLanguage, LANGUAGE_LABELS } from "shared/config";
+import { Loader, Table } from "shared/ui";
+import {
+    formatAdminDateTime,
+    formatAdminWaitTime,
+    getCompletedSubmissions,
+    getInactiveUsers,
+    getPendingDuelsByType,
+} from "../lib/adminPageHelpers";
+import { AdminSection } from "./AdminSection";
+
+import styles from "./AdminPage.module.scss";
+
+const pendingDuelLabels = {
+    Friendly: "Ожидающие дружеские дуэли",
+    Group: "Ожидающие групповые дуэли",
+    Tournament: "Ожидающие турнирные дуэли",
+} as const;
+
+const tournamentStatusLabels = {
+    New: "Новый",
+    InProgress: "Идёт",
+    Finished: "Завершён",
+} as const;
+
+const submissionStatusLabels = {
+    Queued: "В очереди",
+    Running: "Проверяется",
+    Done: "Завершена",
+} as const;
+
+interface QueryContentProps {
+    isLoading: boolean;
+    isError: boolean;
+    hasData: boolean;
+    emptyText: string;
+}
+
+const QueryContent = ({
+    isLoading,
+    isError,
+    hasData,
+    emptyText,
+    children,
+}: PropsWithChildren<QueryContentProps>) => {
+    if (isLoading && !hasData) {
+        return <Loader className={styles.loader} />;
+    }
+
+    if (isError && !hasData) {
+        return <div className={styles.message}>Не удалось загрузить данные.</div>;
+    }
+
+    if (!hasData) {
+        return <div className={styles.message}>{emptyText}</div>;
+    }
+
+    return children;
+};
+
+const UserLink = ({ user }: { user: Pick<UserData, "nickname"> }) => (
+    <Link
+        className={styles.entityLink}
+        to={AppRoutes.PROFILE.replace(":userNickname", user.nickname)}
+    >
+        {user.nickname}
+    </Link>
+);
+
+const Acceptance = ({ accepted }: { accepted: boolean }) => (
+    <span className={accepted ? styles.accepted : styles.waiting}>
+        <span className={styles.statusDot} aria-hidden="true" />
+        {accepted ? "Принял" : "Ожидается"}
+    </span>
+);
+
+const UsersTable = ({ users, isActive }: { users: UserData[]; isActive: boolean }) => (
+    <div className={styles.tableWrapper}>
+        <Table className={styles.table}>
+            <thead>
+                <tr>
+                    <th>Пользователь</th>
+                    <th>Рейтинг</th>
+                    <th>Регистрация</th>
+                    <th>Статус</th>
+                </tr>
+            </thead>
+            <tbody>
+                {users.map((user) => (
+                    <tr key={user.id}>
+                        <td>
+                            <UserLink user={user} />
+                        </td>
+                        <td>{user.rating}</td>
+                        <td>{formatAdminDateTime(user.created_at)}</td>
+                        <td>
+                            <span className={isActive ? styles.active : styles.inactive}>
+                                <span className={styles.statusDot} aria-hidden="true" />
+                                {isActive ? "Онлайн" : "Не в сети"}
+                            </span>
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </Table>
+    </div>
+);
+
+const PendingDuelTable = ({ duels }: { duels: PendingDuel[] }) => (
+    <div className={styles.tableWrapper}>
+        <Table className={styles.table}>
+            <thead>
+                <tr>
+                    <th>Участник 1</th>
+                    <th>Статус</th>
+                    <th>Участник 2</th>
+                    <th>Статус</th>
+                    <th>Контекст</th>
+                    <th>Создана</th>
+                </tr>
+            </thead>
+            <tbody>
+                {duels.map((duel) => {
+                    const groupPath = duel.group_id
+                        ? AppRoutes.GROUP_MEMBERS.replace(":groupId", String(duel.group_id))
+                        : null;
+                    const tournamentPath =
+                        duel.group_id && duel.tournament_id
+                            ? AppRoutes.GROUP_TOURNAMENT.replace(
+                                  ":groupId",
+                                  String(duel.group_id),
+                              ).replace(":tournamentId", String(duel.tournament_id))
+                            : null;
+
+                    return (
+                        <tr key={`${duel.type}-${duel.id}`}>
+                            <td>
+                                <UserLink user={duel.user1} />
+                            </td>
+                            <td>
+                                <Acceptance accepted={duel.is_accepted_by_user1} />
+                            </td>
+                            <td>
+                                <UserLink user={duel.user2} />
+                            </td>
+                            <td>
+                                <Acceptance accepted={duel.is_accepted_by_user2} />
+                            </td>
+                            <td>
+                                <div className={styles.contextLinks}>
+                                    {groupPath && (
+                                        <Link className={styles.entityLink} to={groupPath}>
+                                            {duel.group_name ?? `Группа #${duel.group_id}`}
+                                        </Link>
+                                    )}
+                                    {tournamentPath && (
+                                        <Link className={styles.entityLink} to={tournamentPath}>
+                                            {duel.tournament_name ??
+                                                `Турнир #${duel.tournament_id}`}
+                                        </Link>
+                                    )}
+                                    {!groupPath && !tournamentPath && "Дружеская"}
+                                </div>
+                            </td>
+                            <td>{formatAdminDateTime(duel.created_at)}</td>
+                        </tr>
+                    );
+                })}
+            </tbody>
+        </Table>
+    </div>
+);
+
+const DuelTable = ({ duels, finished }: { duels: Duel[]; finished: boolean }) => (
+    <div className={styles.tableWrapper}>
+        <Table className={styles.table}>
+            <thead>
+                <tr>
+                    <th>Дуэль</th>
+                    <th>Участники</th>
+                    <th>Режим</th>
+                    <th>{finished ? "Завершена" : "Начата"}</th>
+                    <th>Статус</th>
+                </tr>
+            </thead>
+            <tbody>
+                {duels.map((duel) => (
+                    <tr key={duel.id}>
+                        <td>
+                            <Link
+                                className={styles.entityLink}
+                                to={AppRoutes.DUEL.replace(":duelId", String(duel.id))}
+                            >
+                                #{duel.id}
+                            </Link>
+                        </td>
+                        <td>
+                            <div className={styles.participants}>
+                                {(duel.participants ?? []).map((participant, index) => (
+                                    <span key={participant.id}>
+                                        {index > 0 && <span className={styles.separator}>vs</span>}
+                                        <UserLink user={participant} />
+                                    </span>
+                                ))}
+                            </div>
+                        </td>
+                        <td>{duel.is_rated ? "Рейтинговая" : "Нерейтинговая"}</td>
+                        <td>
+                            {formatAdminDateTime(
+                                finished ? (duel.end_time ?? duel.start_time) : duel.start_time,
+                            )}
+                        </td>
+                        <td>
+                            <span className={finished ? styles.inactive : styles.active}>
+                                <span className={styles.statusDot} aria-hidden="true" />
+                                {finished ? "Завершена" : "Идёт"}
+                            </span>
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </Table>
+    </div>
+);
+
+const SubmissionsTable = ({ submissions }: { submissions: SubmissionItem[] }) => (
+    <div className={styles.tableWrapper}>
+        <Table className={styles.table}>
+            <thead>
+                <tr>
+                    <th>Посылка</th>
+                    <th>Пользователь</th>
+                    <th>Отправлена</th>
+                    <th>Язык</th>
+                    <th>Статус</th>
+                </tr>
+            </thead>
+            <tbody>
+                {submissions.map((submission) => (
+                    <tr key={submission.submission_id}>
+                        <td>#{submission.submission_id}</td>
+                        <td>{submission.author ? <UserLink user={submission.author} /> : "—"}</td>
+                        <td>{formatAdminDateTime(submission.created_at)}</td>
+                        <td>{LANGUAGE_LABELS[fromApiLanguage(submission.language)]}</td>
+                        <td>
+                            <span
+                                className={
+                                    submission.status === "Done" ? styles.inactive : styles.waiting
+                                }
+                            >
+                                <span className={styles.statusDot} aria-hidden="true" />
+                                {submission.status === "Done"
+                                    ? (submission.verdict ?? submissionStatusLabels.Done)
+                                    : submissionStatusLabels[submission.status]}
+                            </span>
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </Table>
+    </div>
+);
+
+const TournamentsTable = ({
+    tournaments,
+    groupsById,
+}: {
+    tournaments: Tournament[];
+    groupsById: Map<number, string>;
+}) => (
+    <div className={styles.tableWrapper}>
+        <Table className={styles.table}>
+            <thead>
+                <tr>
+                    <th>Турнир</th>
+                    <th>Группа</th>
+                    <th>Статус</th>
+                    <th>Создан</th>
+                </tr>
+            </thead>
+            <tbody>
+                {tournaments.map((tournament) => {
+                    const groupPath = AppRoutes.GROUP_MEMBERS.replace(
+                        ":groupId",
+                        String(tournament.group_id),
+                    );
+                    const tournamentPath = AppRoutes.GROUP_TOURNAMENT.replace(
+                        ":groupId",
+                        String(tournament.group_id),
+                    ).replace(":tournamentId", String(tournament.id));
+
+                    return (
+                        <tr key={tournament.id}>
+                            <td>
+                                <Link className={styles.entityLink} to={tournamentPath}>
+                                    {tournament.name ?? `Турнир #${tournament.id}`}
+                                </Link>
+                            </td>
+                            <td>
+                                <Link className={styles.entityLink} to={groupPath}>
+                                    {groupsById.get(tournament.group_id) ??
+                                        `Группа #${tournament.group_id}`}
+                                </Link>
+                            </td>
+                            <td>
+                                <span
+                                    className={
+                                        tournament.status === "InProgress"
+                                            ? styles.active
+                                            : tournament.status === "New"
+                                              ? styles.waiting
+                                              : styles.inactive
+                                    }
+                                >
+                                    <span className={styles.statusDot} aria-hidden="true" />
+                                    {tournamentStatusLabels[tournament.status]}
+                                </span>
+                            </td>
+                            <td>{formatAdminDateTime(tournament.created_at)}</td>
+                        </tr>
+                    );
+                })}
+            </tbody>
+        </Table>
+    </div>
+);
+
+const isForbiddenError = (error: unknown) =>
+    typeof error === "object" && error !== null && "status" in error && error.status === 403;
+
+export const AdminPage = () => {
+    const [now, setNow] = useState(() => Date.now());
+
+    useEffect(() => {
+        const timer = window.setInterval(() => setNow(Date.now()), 1000);
+        return () => window.clearInterval(timer);
+    }, []);
+
+    const usersQuery = useGetAdminUsersQuery();
+    const activeUsersQuery = useGetAdminActiveUsersQuery();
+    const pendingDuelsQuery = useGetAdminPendingDuelsQuery();
+    const rankedSearchersQuery = useGetAdminRankedDuelSearchersQuery();
+    const activeDuelsQuery = useGetAdminActiveDuelsQuery();
+    const finishedDuelsQuery = useGetAdminFinishedDuelsQuery();
+    const testingSubmissionsQuery = useGetAdminTestingSubmissionsQuery();
+    const submissionsQuery = useGetAdminSubmissionsQuery();
+    const groupsQuery = useGetAdminGroupsQuery();
+    const activeTournamentsQuery = useGetAdminActiveTournamentsQuery();
+    const finishedTournamentsQuery = useGetAdminFinishedTournamentsQuery();
+
+    const activeUsers = activeUsersQuery.data ?? [];
+    const inactiveUsers = useMemo(
+        () => getInactiveUsers(usersQuery.data ?? [], activeUsersQuery.data ?? []),
+        [usersQuery.data, activeUsersQuery.data],
+    );
+    const pendingDuels = pendingDuelsQuery.data ?? [];
+    const testingSubmissions = testingSubmissionsQuery.data ?? [];
+    const completedSubmissions = useMemo(
+        () => getCompletedSubmissions(submissionsQuery.data ?? []),
+        [submissionsQuery.data],
+    );
+    const groups = groupsQuery.data ?? [];
+    const groupsById = useMemo(
+        () => new Map((groupsQuery.data ?? []).map((group) => [group.id, group.name])),
+        [groupsQuery.data],
+    );
+
+    const queryErrors = [
+        usersQuery.error,
+        activeUsersQuery.error,
+        pendingDuelsQuery.error,
+        rankedSearchersQuery.error,
+        activeDuelsQuery.error,
+        finishedDuelsQuery.error,
+        testingSubmissionsQuery.error,
+        submissionsQuery.error,
+        groupsQuery.error,
+        activeTournamentsQuery.error,
+        finishedTournamentsQuery.error,
+    ];
+
+    if (queryErrors.some(isForbiddenError)) {
+        return (
+            <div className={styles.adminPage}>
+                <div className={styles.accessCard}>
+                    <span className={styles.eyebrow}>403</span>
+                    <h1>Нет доступа</h1>
+                    <p>Административная панель доступна только администраторам.</p>
+                    <Link className={styles.backLink} to={AppRoutes.INDEX}>
+                        Вернуться на главную
+                    </Link>
+                </div>
+            </div>
+        );
+    }
+
+    const friendlyDuels = getPendingDuelsByType(pendingDuels, "Friendly");
+    const groupDuels = getPendingDuelsByType(pendingDuels, "Group");
+    const tournamentDuels = getPendingDuelsByType(pendingDuels, "Tournament");
+    const duelCount =
+        (rankedSearchersQuery.data?.length ?? 0) +
+        pendingDuels.length +
+        (activeDuelsQuery.data?.length ?? 0) +
+        (finishedDuelsQuery.data?.length ?? 0);
+    const tournamentCount =
+        (activeTournamentsQuery.data?.length ?? 0) + (finishedTournamentsQuery.data?.length ?? 0);
+
+    return (
+        <div className={styles.adminPage}>
+            <div className={styles.pageContent}>
+                <header className={styles.pageHeader}>
+                    <span className={styles.eyebrow}>CoDuels observe</span>
+                    <h1>Административная панель</h1>
+                    <p>Текущее состояние пользователей, дуэлей и соревнований.</p>
+                </header>
+
+                <AdminSection title="Пользователи" count={usersQuery.data?.length}>
+                    <div className={styles.subsection}>
+                        <h2>Активные пользователи</h2>
+                        <QueryContent
+                            isLoading={activeUsersQuery.isLoading}
+                            isError={activeUsersQuery.isError}
+                            hasData={activeUsers.length > 0}
+                            emptyText="Сейчас нет активных пользователей."
+                        >
+                            <UsersTable users={activeUsers} isActive />
+                        </QueryContent>
+                    </div>
+                    <div className={styles.subsection}>
+                        <h2>Остальные пользователи</h2>
+                        <QueryContent
+                            isLoading={usersQuery.isLoading || activeUsersQuery.isLoading}
+                            isError={usersQuery.isError || activeUsersQuery.isError}
+                            hasData={inactiveUsers.length > 0}
+                            emptyText="Других пользователей нет."
+                        >
+                            <UsersTable users={inactiveUsers} isActive={false} />
+                        </QueryContent>
+                    </div>
+                </AdminSection>
+
+                <AdminSection title="Дуэли" count={duelCount}>
+                    <div className={styles.subsection}>
+                        <h2>Поиск рейтинговой дуэли</h2>
+                        <QueryContent
+                            isLoading={rankedSearchersQuery.isLoading}
+                            isError={rankedSearchersQuery.isError}
+                            hasData={Boolean(rankedSearchersQuery.data?.length)}
+                            emptyText="Никто не ищет рейтинговую дуэль."
+                        >
+                            <div className={styles.tableWrapper}>
+                                <Table className={styles.table}>
+                                    <thead>
+                                        <tr>
+                                            <th>Пользователь</th>
+                                            <th>Рейтинг поиска</th>
+                                            <th>Ожидает</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {(rankedSearchersQuery.data ?? []).map((searcher) => (
+                                            <tr key={searcher.user.id}>
+                                                <td>
+                                                    <UserLink user={searcher.user} />
+                                                </td>
+                                                <td>{searcher.rating}</td>
+                                                <td>
+                                                    {formatAdminWaitTime(
+                                                        searcher.search_started_at,
+                                                        now,
+                                                    )}
+                                                </td>
+                                            </tr>
+                                        ))}
+                                    </tbody>
+                                </Table>
+                            </div>
+                        </QueryContent>
+                    </div>
+
+                    {(
+                        [
+                            ["Friendly", friendlyDuels],
+                            ["Group", groupDuels],
+                            ["Tournament", tournamentDuels],
+                        ] as const
+                    ).map(([type, duels]) => (
+                        <div className={styles.subsection} key={type}>
+                            <h2>{pendingDuelLabels[type]}</h2>
+                            <QueryContent
+                                isLoading={pendingDuelsQuery.isLoading}
+                                isError={pendingDuelsQuery.isError}
+                                hasData={duels.length > 0}
+                                emptyText="Нет ожидающих дуэлей этого типа."
+                            >
+                                <PendingDuelTable duels={duels} />
+                            </QueryContent>
+                        </div>
+                    ))}
+
+                    <div className={styles.subsection}>
+                        <h2>Дуэли в процессе</h2>
+                        <QueryContent
+                            isLoading={activeDuelsQuery.isLoading}
+                            isError={activeDuelsQuery.isError}
+                            hasData={Boolean(activeDuelsQuery.data?.length)}
+                            emptyText="Сейчас нет активных дуэлей."
+                        >
+                            <DuelTable duels={activeDuelsQuery.data ?? []} finished={false} />
+                        </QueryContent>
+                    </div>
+
+                    <div className={styles.subsection}>
+                        <h2>Завершённые дуэли</h2>
+                        <QueryContent
+                            isLoading={finishedDuelsQuery.isLoading}
+                            isError={finishedDuelsQuery.isError}
+                            hasData={Boolean(finishedDuelsQuery.data?.length)}
+                            emptyText="Завершённых дуэлей пока нет."
+                        >
+                            <DuelTable duels={finishedDuelsQuery.data ?? []} finished />
+                        </QueryContent>
+                    </div>
+                </AdminSection>
+
+                <AdminSection title="Посылки" count={submissionsQuery.data?.length}>
+                    <div className={styles.subsection}>
+                        <h2>Тестируются</h2>
+                        <QueryContent
+                            isLoading={testingSubmissionsQuery.isLoading}
+                            isError={testingSubmissionsQuery.isError}
+                            hasData={testingSubmissions.length > 0}
+                            emptyText="Сейчас нет тестирующихся посылок."
+                        >
+                            <SubmissionsTable submissions={testingSubmissions} />
+                        </QueryContent>
+                    </div>
+                    <div className={styles.subsection}>
+                        <h2>Протестированы</h2>
+                        <QueryContent
+                            isLoading={submissionsQuery.isLoading}
+                            isError={submissionsQuery.isError}
+                            hasData={completedSubmissions.length > 0}
+                            emptyText="Протестированных посылок пока нет."
+                        >
+                            <SubmissionsTable submissions={completedSubmissions} />
+                        </QueryContent>
+                    </div>
+                </AdminSection>
+
+                <AdminSection title="Группы" count={groupsQuery.data?.length}>
+                    <QueryContent
+                        isLoading={groupsQuery.isLoading}
+                        isError={groupsQuery.isError}
+                        hasData={groups.length > 0}
+                        emptyText="Групп пока нет."
+                    >
+                        <div className={styles.tableWrapper}>
+                            <Table className={styles.table}>
+                                <thead>
+                                    <tr>
+                                        <th>Название</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {groups.map((group) => (
+                                        <tr key={group.id}>
+                                            <td>
+                                                <Link
+                                                    className={styles.entityLink}
+                                                    to={AppRoutes.GROUP_MEMBERS.replace(
+                                                        ":groupId",
+                                                        String(group.id),
+                                                    )}
+                                                >
+                                                    {group.name}
+                                                </Link>
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </Table>
+                        </div>
+                    </QueryContent>
+                </AdminSection>
+
+                <AdminSection title="Турниры" count={tournamentCount}>
+                    <div className={styles.subsection}>
+                        <h2>Активные турниры</h2>
+                        <QueryContent
+                            isLoading={activeTournamentsQuery.isLoading}
+                            isError={activeTournamentsQuery.isError}
+                            hasData={Boolean(activeTournamentsQuery.data?.length)}
+                            emptyText="Активных турниров нет."
+                        >
+                            <TournamentsTable
+                                tournaments={activeTournamentsQuery.data ?? []}
+                                groupsById={groupsById}
+                            />
+                        </QueryContent>
+                    </div>
+                    <div className={styles.subsection}>
+                        <h2>Прошедшие турниры</h2>
+                        <QueryContent
+                            isLoading={finishedTournamentsQuery.isLoading}
+                            isError={finishedTournamentsQuery.isError}
+                            hasData={Boolean(finishedTournamentsQuery.data?.length)}
+                            emptyText="Завершённых турниров пока нет."
+                        >
+                            <TournamentsTable
+                                tournaments={finishedTournamentsQuery.data ?? []}
+                                groupsById={groupsById}
+                            />
+                        </QueryContent>
+                    </div>
+                </AdminSection>
+            </div>
+        </div>
+    );
+};

--- a/src/pages/admin/ui/AdminPage.tsx
+++ b/src/pages/admin/ui/AdminPage.tsx
@@ -11,7 +11,7 @@ import {
 } from "entities/duel";
 import { useGetAdminGroupsQuery } from "entities/group";
 import {
-    type SubmissionItem,
+    type AdminSubmissionItem,
     useGetAdminSubmissionsQuery,
     useGetAdminTestingSubmissionsQuery,
 } from "entities/submission";
@@ -28,6 +28,8 @@ import { Loader, Table } from "shared/ui";
 import {
     formatAdminDateTime,
     formatAdminWaitTime,
+    getAdminSubmissionPath,
+    getAdminSubmissionStatus,
     getCompletedSubmissions,
     getInactiveUsers,
     getPendingDuelsByType,
@@ -46,12 +48,6 @@ const tournamentStatusLabels = {
     New: "Новый",
     InProgress: "Идёт",
     Finished: "Завершён",
-} as const;
-
-const submissionStatusLabels = {
-    Queued: "В очереди",
-    Running: "Проверяется",
-    Done: "Завершена",
 } as const;
 
 interface QueryContentProps {
@@ -248,7 +244,7 @@ const DuelTable = ({ duels, finished }: { duels: Duel[]; finished: boolean }) =>
     </div>
 );
 
-const SubmissionsTable = ({ submissions }: { submissions: SubmissionItem[] }) => (
+const SubmissionsTable = ({ submissions }: { submissions: AdminSubmissionItem[] }) => (
     <div className={styles.tableWrapper}>
         <Table className={styles.table}>
             <thead>
@@ -261,26 +257,40 @@ const SubmissionsTable = ({ submissions }: { submissions: SubmissionItem[] }) =>
                 </tr>
             </thead>
             <tbody>
-                {submissions.map((submission) => (
-                    <tr key={submission.submission_id}>
-                        <td>#{submission.submission_id}</td>
-                        <td>{submission.author ? <UserLink user={submission.author} /> : "—"}</td>
-                        <td>{formatAdminDateTime(submission.created_at)}</td>
-                        <td>{LANGUAGE_LABELS[fromApiLanguage(submission.language)]}</td>
-                        <td>
-                            <span
-                                className={
-                                    submission.status === "Done" ? styles.inactive : styles.waiting
-                                }
-                            >
-                                <span className={styles.statusDot} aria-hidden="true" />
-                                {submission.status === "Done"
-                                    ? (submission.verdict ?? submissionStatusLabels.Done)
-                                    : submissionStatusLabels[submission.status]}
-                            </span>
-                        </td>
-                    </tr>
-                ))}
+                {submissions.map((submission) => {
+                    const status = getAdminSubmissionStatus(submission);
+                    const statusClassName =
+                        status.tone === "accepted"
+                            ? styles.submissionAccepted
+                            : status.tone === "rejected"
+                              ? styles.submissionRejected
+                              : styles.submissionTesting;
+
+                    return (
+                        <tr key={submission.submission_id}>
+                            <td>
+                                <Link
+                                    className={styles.entityLink}
+                                    to={getAdminSubmissionPath(submission)}
+                                    aria-label={`Открыть посылку #${submission.submission_id}`}
+                                >
+                                    #{submission.submission_id}
+                                </Link>
+                            </td>
+                            <td>
+                                {submission.author ? <UserLink user={submission.author} /> : "—"}
+                            </td>
+                            <td>{formatAdminDateTime(submission.created_at)}</td>
+                            <td>{LANGUAGE_LABELS[fromApiLanguage(submission.language)]}</td>
+                            <td>
+                                <span className={statusClassName}>
+                                    <span className={styles.statusDot} aria-hidden="true" />
+                                    {status.label}
+                                </span>
+                            </td>
+                        </tr>
+                    );
+                })}
             </tbody>
         </Table>
     </div>

--- a/src/pages/admin/ui/AdminPage.tsx
+++ b/src/pages/admin/ui/AdminPage.tsx
@@ -21,7 +21,9 @@ import {
     useGetAdminFinishedTournamentsQuery,
 } from "entities/tournament";
 import { type UserData, useGetAdminActiveUsersQuery, useGetAdminUsersQuery } from "entities/user";
+import { isAdminAccessToken, selectAuthToken } from "features/auth";
 import { AppRoutes, fromApiLanguage, LANGUAGE_LABELS } from "shared/config";
+import { useAppSelector } from "shared/lib/storeHooks";
 import { Loader, Table } from "shared/ui";
 import {
     formatAdminDateTime,
@@ -351,25 +353,44 @@ const TournamentsTable = ({
 const isForbiddenError = (error: unknown) =>
     typeof error === "object" && error !== null && "status" in error && error.status === 403;
 
+const AccessDenied = () => (
+    <div className={styles.adminPage}>
+        <div className={styles.accessCard}>
+            <span className={styles.eyebrow}>403</span>
+            <h1>Нет доступа</h1>
+            <p>Административная панель доступна только администраторам.</p>
+            <Link className={styles.backLink} to={AppRoutes.INDEX}>
+                Вернуться на главную
+            </Link>
+        </div>
+    </div>
+);
+
 export const AdminPage = () => {
     const [now, setNow] = useState(() => Date.now());
+    const token = useAppSelector(selectAuthToken);
+    const isAdmin = isAdminAccessToken(token);
 
     useEffect(() => {
         const timer = window.setInterval(() => setNow(Date.now()), 1000);
         return () => window.clearInterval(timer);
     }, []);
 
-    const usersQuery = useGetAdminUsersQuery();
-    const activeUsersQuery = useGetAdminActiveUsersQuery();
-    const pendingDuelsQuery = useGetAdminPendingDuelsQuery();
-    const rankedSearchersQuery = useGetAdminRankedDuelSearchersQuery();
-    const activeDuelsQuery = useGetAdminActiveDuelsQuery();
-    const finishedDuelsQuery = useGetAdminFinishedDuelsQuery();
-    const testingSubmissionsQuery = useGetAdminTestingSubmissionsQuery();
-    const submissionsQuery = useGetAdminSubmissionsQuery();
-    const groupsQuery = useGetAdminGroupsQuery();
-    const activeTournamentsQuery = useGetAdminActiveTournamentsQuery();
-    const finishedTournamentsQuery = useGetAdminFinishedTournamentsQuery();
+    const skipAdminQueries = { skip: !isAdmin };
+    const usersQuery = useGetAdminUsersQuery(undefined, skipAdminQueries);
+    const activeUsersQuery = useGetAdminActiveUsersQuery(undefined, skipAdminQueries);
+    const pendingDuelsQuery = useGetAdminPendingDuelsQuery(undefined, skipAdminQueries);
+    const rankedSearchersQuery = useGetAdminRankedDuelSearchersQuery(undefined, skipAdminQueries);
+    const activeDuelsQuery = useGetAdminActiveDuelsQuery(undefined, skipAdminQueries);
+    const finishedDuelsQuery = useGetAdminFinishedDuelsQuery(undefined, skipAdminQueries);
+    const testingSubmissionsQuery = useGetAdminTestingSubmissionsQuery(undefined, skipAdminQueries);
+    const submissionsQuery = useGetAdminSubmissionsQuery(undefined, skipAdminQueries);
+    const groupsQuery = useGetAdminGroupsQuery(undefined, skipAdminQueries);
+    const activeTournamentsQuery = useGetAdminActiveTournamentsQuery(undefined, skipAdminQueries);
+    const finishedTournamentsQuery = useGetAdminFinishedTournamentsQuery(
+        undefined,
+        skipAdminQueries,
+    );
 
     const activeUsers = activeUsersQuery.data ?? [];
     const inactiveUsers = useMemo(
@@ -402,19 +423,8 @@ export const AdminPage = () => {
         finishedTournamentsQuery.error,
     ];
 
-    if (queryErrors.some(isForbiddenError)) {
-        return (
-            <div className={styles.adminPage}>
-                <div className={styles.accessCard}>
-                    <span className={styles.eyebrow}>403</span>
-                    <h1>Нет доступа</h1>
-                    <p>Административная панель доступна только администраторам.</p>
-                    <Link className={styles.backLink} to={AppRoutes.INDEX}>
-                        Вернуться на главную
-                    </Link>
-                </div>
-            </div>
-        );
+    if (!isAdmin || queryErrors.some(isForbiddenError)) {
+        return <AccessDenied />;
     }
 
     const friendlyDuels = getPendingDuelsByType(pendingDuels, "Friendly");

--- a/src/pages/admin/ui/AdminSection.tsx
+++ b/src/pages/admin/ui/AdminSection.tsx
@@ -1,0 +1,33 @@
+import { useState, type PropsWithChildren } from "react";
+
+import styles from "./AdminPage.module.scss";
+
+interface AdminSectionProps {
+    title: string;
+    count?: number;
+    defaultOpen?: boolean;
+}
+
+export const AdminSection = ({
+    title,
+    count,
+    defaultOpen = true,
+    children,
+}: PropsWithChildren<AdminSectionProps>) => {
+    const [isOpen, setIsOpen] = useState(defaultOpen);
+
+    return (
+        <details
+            className={styles.sectionCard}
+            open={isOpen}
+            onToggle={(event) => setIsOpen(event.currentTarget.open)}
+        >
+            <summary className={styles.sectionSummary}>
+                <span className={styles.sectionTitle}>{title}</span>
+                {typeof count === "number" && <span className={styles.sectionCount}>{count}</span>}
+                <span className={styles.sectionChevron} aria-hidden="true" />
+            </summary>
+            <div className={styles.sectionContent}>{children}</div>
+        </details>
+    );
+};

--- a/src/shared/config/routes/appRoutes.ts
+++ b/src/shared/config/routes/appRoutes.ts
@@ -1,6 +1,7 @@
 export const enum AppRoutes {
     INDEX = "/",
     AUTH = "/auth",
+    ADMIN = "/admin",
     PROFILE = "/profile/:userNickname",
     GROUPS = "/groups",
     GROUP = "/groups/:groupId",

--- a/src/widgets/task-panel/ui/TaskPanel/TaskPanel.tsx
+++ b/src/widgets/task-panel/ui/TaskPanel/TaskPanel.tsx
@@ -11,6 +11,7 @@ import {
 
 import { useDuelTaskSelection, useGetDuelQuery } from "entities/duel";
 import { selectCurrentUser } from "entities/user";
+import { isAdminAccessToken, selectAuthToken } from "features/auth";
 import DescriptionIcon from "shared/assets/icons/document.svg?react";
 import SubmissionsIcon from "shared/assets/icons/inbox.svg?react";
 import { AppRoutes } from "shared/config";
@@ -27,6 +28,8 @@ export const TaskPanel = () => {
         skip: !duelId,
     });
     const currentUser = useAppSelector(selectCurrentUser);
+    const token = useAppSelector(selectAuthToken);
+    const isAdmin = isAdminAccessToken(token);
     const [searchParams] = useSearchParams();
     const { tasks, selectedTaskKey } = useDuelTaskSelection(duel);
     const selectedTaskValue = selectedTaskKey ?? tasks[0]?.key ?? "";
@@ -85,7 +88,7 @@ export const TaskPanel = () => {
                 </div>
             ) : null}
             <TabbedCard tabs={tabs} contentClassName={styles.taskPanelContent}>
-                {duel && !isParticipant && isSubmissionCodeRoute ? (
+                {duel && !isParticipant && !isAdmin && isSubmissionCodeRoute ? (
                     <Navigate
                         to={{ pathname: `/duel/${duelId}/submissions`, search: location.search }}
                         replace

--- a/src/widgets/task-panel/ui/TaskSubmissionsContent/TaskSubmissionsContent.tsx
+++ b/src/widgets/task-panel/ui/TaskSubmissionsContent/TaskSubmissionsContent.tsx
@@ -4,6 +4,7 @@ import { Loader, Table } from "shared/ui";
 import { useGetSubmissionsQuery } from "features/submit-code";
 import { useDuelTaskSelection, useGetDuelQuery } from "entities/duel";
 import { selectCurrentUser } from "entities/user";
+import { isAdminAccessToken, selectAuthToken } from "features/auth";
 import { useAppSelector } from "shared/lib/storeHooks";
 import {
     shouldPollSubmissionStatus,
@@ -16,6 +17,8 @@ export const TaskSubmissionsContent = () => {
     const { duelId } = useParams();
     const [searchParams] = useSearchParams();
     const currentUser = useAppSelector(selectCurrentUser);
+    const token = useAppSelector(selectAuthToken);
+    const isAdmin = isAdminAccessToken(token);
     const { data: duel, isLoading: isDuelLoading } = useGetDuelQuery(Number(duelId!), {
         skip: !duelId,
     });
@@ -94,7 +97,7 @@ export const TaskSubmissionsContent = () => {
                         duelId={duelId}
                         taskKey={resolvedTaskKey}
                         showAuthor={isViewer}
-                        canOpenDetail={!isViewer}
+                        canOpenDetail={!isViewer || isAdmin}
                     />
                 ))}
             </tbody>


### PR DESCRIPTION
## Summary

- add the protected `/admin` dashboard with five collapsible sections for users, duels, submissions, groups, and tournaments
- consume all eleven admin list endpoints from Backend PR https://github.com/DIvanCode/CoDuels-Backend/pull/337 through the shared RTK Query slice
- separate active users and completed submissions on the client, show live ranked-search wait time, and link users, groups, tournaments, and duels to their existing pages
- render testing submissions in yellow, `Accepted` in green, and every other terminal verdict in red
- link every admin submission row directly to its detail inside the owning duel and preserve the task selection
- let administrators open submission details while keeping the duel/code UI read-only for non-participants
- keep authenticated non-admins on `/admin` with a dedicated access-denied screen without starting admin requests or clearing their session
- add loading, empty, partial-failure, and 403 states plus responsive table styling
- document the dashboard flow and backend contracts

## Backend dependency and contract gaps

This PR depends on https://github.com/DIvanCode/CoDuels-Backend/pull/337. Its admin submission-list DTO provides `duel_id` and `task_key`, and its regular duel/submission read endpoints allow administrator access.

The current backend contract does not expose the Friendly/Group/Tournament origin or group/tournament references on active and finished `DuelDto` records. Those lists therefore show rated versus unrated mode but cannot yet be grouped by origin. `TournamentDto` also exposes `created_at`, not a tournament start time, so the dashboard labels that column as creation time.

## Verification

- `pnpm test` — 26 files, 82 tests passed
- `pnpm lint` — passed; 4 pre-existing repository warnings remain
- `pnpm fsd:lint` — existing baseline remains at 12 errors and 11 warnings; the admin change adds no new finding
- `VITE_BASE_URL=/api pnpm build` — passed
- the final production `dist` was served with Vite preview and smoke-tested in headless Chrome:
  - non-admin stayed at `/admin`, remained authenticated, saw “Нет доступа”, and made 0 admin requests
  - admin stayed at `/admin`, made all 11 admin requests, and saw all 5 dashboard sections
  - admin rows rendered `Accepted` in green, `Wrong answer` in red, and `Running` as yellow “Проверяется”
  - clicking submission #101 opened `/duel/77/submissions/101?task=B` and rendered its Accepted detail
  - all scenarios mounted a non-empty `#root` without uncaught exceptions or an application error-boundary

## What to test manually

Prerequisites: an administrator account, a non-admin account, Backend PR 337 available in the test environment, and representative active/inactive users, pending/in-progress/finished duels, submissions, groups, and tournaments.

1. Sign in as an administrator and open `/admin`.
2. Collapse and reopen every main section; each should keep its tables and counts.
3. Confirm active users are listed first and are absent from the remaining-users table.
4. Confirm ranked searchers, all three pending-duel types, active duels, and finished duels appear in the documented order; open user/group/tournament/duel links.
5. In “Посылки”, confirm queued/running rows are yellow, `Accepted` rows are green, and every other completed verdict is red.
6. Click a submission number; expect `/duel/{duelId}/submissions/{submissionId}?task={taskKey}`, the correct task, and the selected submission detail without a redirect.
7. Click “Все решения”; as an administrator, expect both participants' submissions to remain visible and openable while editing/submitting stays unavailable.
8. Sign in as a non-admin and open `/admin`; expect “Нет доступа”, no redirect to `/auth`, and a preserved authenticated session.
9. Follow “Вернуться на главную” and confirm the non-admin can continue using the application without signing in again.
10. Recheck the dashboard in light/dark themes and a narrow viewport; wide tables should scroll without breaking the page.

Closes #89